### PR TITLE
Removal of PHP short-tags

### DIFF
--- a/PHPCI/View/Build.phtml
+++ b/PHPCI/View/Build.phtml
@@ -1,6 +1,6 @@
 <div id="title">
-	<h1 style="display: inline-block">Build #<?= $build->getId(); ?></h1>
-			<h3 style="margin-left: 40px; display: inline-block">Branch: <?= $build->getBranch(); ?> - <?= $build->getCommitId() == 'Manual' ? 'Manual Build' : 'Commit: ' . $build->getCommitId(); ?></h3>
+	<h1 style="display: inline-block">Build #<?php echo $build->getId(); ?></h1>
+			<h3 style="margin-left: 40px; display: inline-block">Branch: <?php echo $build->getBranch(); ?> - <?php echo $build->getCommitId() == 'Manual' ? 'Manual Build' : 'Commit: ' . $build->getCommitId(); ?></h3>
 </div>
 
 <div class="row">
@@ -8,12 +8,12 @@
 		<div class="well" style="padding: 8px 0">
 		<ul class="nav nav-list">
 			<li><a href="/"><i class="icon-home"></i> Dashboard</a></li>
-			<li><a href="/project/view/<?= $build->getProject()->getId(); ?>"><i class="icon-folder-open"></i> <?= $build->getProject()->getTitle(); ?></a></li>
+			<li><a href="/project/view/<?php echo $build->getProject()->getId(); ?>"><i class="icon-folder-open"></i> <?php echo $build->getProject()->getTitle(); ?></a></li>
 			<li class="divider"></li>
 			<li class="nav-header">Options</li>
-			<li><a href="/build/rebuild/<?= $build->getId(); ?>"><i class="icon-cog"></i> Rebuild</a></li>
+			<li><a href="/build/rebuild/<?php echo $build->getId(); ?>"><i class="icon-cog"></i> Rebuild</a></li>
 			<?php if($this->User()->getIsAdmin()): ?>
-			<li><a href="javascript:confirmDelete('/build/delete/<?= $build->getId(); ?>')"><i class="icon-trash"></i> Delete Build</a></li>
+			<li><a href="javascript:confirmDelete('/build/delete/<?php echo $build->getId(); ?>')"><i class="icon-trash"></i> Delete Build</a></li>
 			<?php endif; ?>
 		</ul>
 		</div>
@@ -25,7 +25,7 @@
 			</tr>
 			</thead>
 			<tbody id="plugins">
-				<?= $plugins; ?>
+				<?php echo $plugins; ?>
 			</tbody>
 		</table>
 	</div>
@@ -68,13 +68,13 @@
 <script>
 setInterval(function()
 {
-	$.getJSON('/build/data/<?= $build->getId(); ?>', updateBuildView);
+	$.getJSON('/build/data/<?php echo $build->getId(); ?>', updateBuildView);
 }, 10000);
 </script>
 <?php endif; ?>
 
 <script>
-	window.initial = <?= $data; ?>;
+	window.initial = <?php echo $data; ?>;
 
 	function updateBuildView(data)
 	{

--- a/PHPCI/View/BuildsTable.phtml
+++ b/PHPCI/View/BuildsTable.phtml
@@ -30,21 +30,21 @@ switch($build->getStatus())
 	break;
 }
 ?>
-<tr class="<?= $cls; ?>">
-	<td><a href="/build/view/<?= $build->getId(); ?>">#<?= str_pad($build->getId(), 6, '0', STR_PAD_LEFT); ?></a></td>
-	<td><a href="/project/view/<?= $build->getProjectId(); ?>"><?= $build->getProject()->getTitle(); ?></a></td>
-	<td><a href="<?= $build->getCommitLink(); ?>"><?= $build->getCommitId(); ?></a></td>
-	<td><a href="<?= $build->getBranchLink(); ?>"><?= $build->getBranch(); ?></a></td>
-	<td><?= $status; ?></td>
+<tr class="<?php echo $cls; ?>">
+	<td><a href="/build/view/<?php echo $build->getId(); ?>">#<?php echo str_pad($build->getId(), 6, '0', STR_PAD_LEFT); ?></a></td>
+	<td><a href="/project/view/<?php echo $build->getProjectId(); ?>"><?php echo $build->getProject()->getTitle(); ?></a></td>
+	<td><a href="<?php echo $build->getCommitLink(); ?>"><?php echo $build->getCommitId(); ?></a></td>
+	<td><a href="<?php echo $build->getBranchLink(); ?>"><?php echo $build->getBranch(); ?></a></td>
+	<td><?php echo $status; ?></td>
 	<td>
 		<div class="btn-group">
-			<a class="btn" href="/build/view/<?= $build->getId(); ?>">View</a>
+			<a class="btn" href="/build/view/<?php echo $build->getId(); ?>">View</a>
 			<?php if($this->User()->getIsAdmin()): ?>
 			<button class="btn dropdown-toggle" data-toggle="dropdown">
 				<span class="caret"></span>
 			</button>
 			<ul class="dropdown-menu">
-				<li><a href="javascript:confirmDelete('/build/delete/<?= $build->getId(); ?>');">Delete Build</a></li>
+				<li><a href="javascript:confirmDelete('/build/delete/<?php echo $build->getId(); ?>');">Delete Build</a></li>
 			</ul>
 			<?php endif; ?>
 		</div>

--- a/PHPCI/View/Index.phtml
+++ b/PHPCI/View/Index.phtml
@@ -11,7 +11,7 @@
 			<li class="nav-header">Projects</li>
 
 			<?php foreach($projects as $project): ?>
-			<li><a href="/project/view/<?= $project->getId(); ?>"><i class="icon-folder-open"></i> <?= $project->getTitle(); ?></a></li>
+			<li><a href="/project/view/<?php echo $project->getId(); ?>"><i class="icon-folder-open"></i> <?php echo $project->getTitle(); ?></a></li>
 			<?php endforeach; ?>
 		</ul>
 		</div>
@@ -29,7 +29,7 @@
 			</tr>
 			</thead>
 			<tbody id="latest-builds">
-				<?= $builds; ?>
+				<?php echo $builds; ?>
 			</tbody>
 		</table>
 	</div>

--- a/PHPCI/View/Layout.phtml
+++ b/PHPCI/View/Layout.phtml
@@ -91,7 +91,7 @@
 		</div>
 
 		<div id="content" class="container">
-			<?= $content; ?>
+			<?php echo $content; ?>
 		</div>
 	</body>
 </html>

--- a/PHPCI/View/Login.phtml
+++ b/PHPCI/View/Login.phtml
@@ -43,7 +43,7 @@
 <div class="container">
 	<div class="row" style="margin-top: 10%; text-align: center">
 		<div class="" id="login-box">
-			<?= $form; ?>
+			<?php echo $form; ?>
 		</div>
 
 		<a id="logo" href="http://www.block8.co.uk/"><img src="http://cms.block8.co.uk/assets/img/small-logo-trans-white.png"></a>

--- a/PHPCI/View/Project.phtml
+++ b/PHPCI/View/Project.phtml
@@ -1,5 +1,5 @@
 <div id="title">
-	<h1>Project: <?= $project->getTitle(); ?></h1>
+	<h1>Project: <?php echo $project->getTitle(); ?></h1>
 </div>
 
 <div class="row">
@@ -7,14 +7,14 @@
 		<div class="well" style="padding: 8px 0">
 		<ul class="nav nav-list">
 			<li><a href="/"><i class="icon-home"></i> Dashboard</a></li>
-			<li><a href="/project/view/<?= $project->getId(); ?>"><i class="icon-folder-open"></i> <?= $project->getTitle(); ?></a></li>
+			<li><a href="/project/view/<?php echo $project->getId(); ?>"><i class="icon-folder-open"></i> <?php echo $project->getTitle(); ?></a></li>
 			<li class="divider"></li>
 			<li class="nav-header">Options</li>
-			<li><a href="/project/build/<?= $project->getId(); ?>"><i class="icon-cog"></i> Build Now</a></li>
+			<li><a href="/project/build/<?php echo $project->getId(); ?>"><i class="icon-cog"></i> Build Now</a></li>
 
 			<?php if($this->User()->getIsAdmin()): ?>
-			<li><a href="/project/edit/<?= $project->getId(); ?>"><i class="icon-edit"></i> Edit Project</a></li>
-			<li><a href="javascript:confirmDelete('/project/delete/<?= $project->getId(); ?>')"><i class="icon-trash"></i> Delete Project</a></li>
+			<li><a href="/project/edit/<?php echo $project->getId(); ?>"><i class="icon-edit"></i> Edit Project</a></li>
+			<li><a href="javascript:confirmDelete('/project/delete/<?php echo $project->getId(); ?>')"><i class="icon-trash"></i> Delete Project</a></li>
 			<?php endif; ?>
 		</ul>
 		</div>
@@ -51,7 +51,7 @@
 			</tr>
 			</thead>
 			<tbody id="latest-builds">
-				<?= $builds; ?>
+				<?php echo $builds; ?>
 			</tbody>
 		</table>
 
@@ -80,7 +80,7 @@
 <script>
 setInterval(function()
 {
-	$('#latest-builds').load('/project/builds/<?= $project->getId(); ?>');
+	$('#latest-builds').load('/project/builds/<?php echo $project->getId(); ?>');
 }, 10000);
 </script>
 <?php endif; ?>

--- a/PHPCI/View/ProjectForm.phtml
+++ b/PHPCI/View/ProjectForm.phtml
@@ -1,5 +1,5 @@
 <div id="title">
-	<h1><?= $type == 'add' ? 'Add Project' : 'Edit Project' ?></h1>
+	<h1><?php echo $type == 'add' ? 'Add Project' : 'Edit Project' ?></h1>
 </div>
 
 <div class="row">
@@ -8,7 +8,7 @@
 			<?php if(!is_null($key)): ?>
 			<p>To make it easier to get started, we've generated a public / private key pair for you to use for this project. To use it, just add the following public key to the "deploy keys" section of your repository settings on Github / Bitbucket.</p>
 
-			<textarea style="width: 90%; height: 150px;"><?= $key ?></textarea>
+			<textarea style="width: 90%; height: 150px;"><?php echo $key ?></textarea>
 			<?php elseif($type == 'add'): ?>
 			<p>Fill in the form to the right to add your new project.</p>
 			<?php else: ?>
@@ -17,7 +17,7 @@
 		</div>
 	</div>
 	<div class="span8">
-		<?= $form; ?>
+		<?php echo $form; ?>
 	</div>
 </div>
 

--- a/PHPCI/View/User.phtml
+++ b/PHPCI/View/User.phtml
@@ -40,19 +40,19 @@
 					break;
 				}
 				?>
-				<tr class="<?= $cls; ?>">
-					<td><a href="/user/edit/<?= $user->getId(); ?>"><?= $user->getEmail(); ?></a></td>
-					<td><?= $user->getName(); ?></td>
-					<td><?= $status; ?></td>
+				<tr class="<?php echo $cls; ?>">
+					<td><a href="/user/edit/<?php echo $user->getId(); ?>"><?php echo $user->getEmail(); ?></a></td>
+					<td><?php echo $user->getName(); ?></td>
+					<td><?php echo $status; ?></td>
 					<td>
 						<?php if($this->User()->getIsAdmin()): ?>
 						<div class="btn-group">
-							<a class="btn" href="/user/edit/<?= $user->getId(); ?>">Edit</a>
+							<a class="btn" href="/user/edit/<?php echo $user->getId(); ?>">Edit</a>
 							<button class="btn dropdown-toggle" data-toggle="dropdown">
 								<span class="caret"></span>
 							</button>
 							<ul class="dropdown-menu">
-								<li><a href="javascript:confirmDelete('/user/delete/<?= $user->getId(); ?>');">Delete User</a></li>
+								<li><a href="javascript:confirmDelete('/user/delete/<?php echo $user->getId(); ?>');">Delete User</a></li>
 							</ul>
 						</div>
 						<?php endif; ?>

--- a/PHPCI/View/UserForm.phtml
+++ b/PHPCI/View/UserForm.phtml
@@ -1,5 +1,5 @@
 <div id="title">
-	<h1><?= $type == 'add' ? 'Add User' : 'Edit ' . $user->getName() ?></h1>
+	<h1><?php echo $type == 'add' ? 'Add User' : 'Edit ' . $user->getName() ?></h1>
 </div>
 
 <div class="row">
@@ -13,6 +13,6 @@
 		</div>
 	</div>
 	<div class="span8">
-		<?= $form; ?>
+		<?php echo $form; ?>
 	</div>
 </div>


### PR DESCRIPTION
I've removed PHP short tags, of the format <?= $foo ?> and replaced them with standard PHP echo tags: <?php echo $foo ?>

I've just spent half an hour trying to figure out why I was getting a blank login page, until I found out that short tags were disabled.  For an open-source project that supports PHP 5.3 and is (presumably) looking for a wide user-base, this feature cannot be relied upon, unfortunately.

I agree that it makes the code less neat, but I think that is the lesser of two evils if this is going to be a serious contender in the CI arena.
