### PR TITLE
Fix for running PHP under CGI on Windows machines.

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -89,6 +89,15 @@ class ProjectController extends b8\Controller
 		else
 		{
 			$tempPath = sys_get_temp_dir() . '/';
+
+			// FastCGI fix for Windows machines, where temp path is not available to
+			// PHP, and defaults to the unwritable system directory.  If the temp
+			// path is pointing to the system directory, shift to the 'TEMP'
+			// sub-folder, which should also exist, but actually be writable.
+			if ($tempPath == getenv("SystemRoot") . '/') {
+				$tempPath = getenv("SystemRoot") . '/TEMP/';
+			}
+
 			$id = $tempPath . md5(microtime(true));
 			if (!is_dir($tempPath)) {
 				mkdir($tempPath);


### PR DESCRIPTION
Fix for running PHP under CGI on Windows machines.  In this situation, the environement variables defining the system temp path are not necessarily available to PHP, so sys_get_temp_dir() falls back to using the system path (e.g. C:\WINDOWS), which is normally unwritable.  This means that temp-file creation fails.

I've added code to detect this situation, and if it occurs we point it to %SystemRoot%\TEMP instead, which usually is present and writable.  May not fix 100% of cases, but should fix the vast majority of situations where this may occur.
