### PR TITLE
Updated minimum PHP version in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _**Please be aware that this is a brand new project, in an alpha state, so there
 
 ##Installing PHPCI:
 ####Pre-requisites:
-* PHP 5.3+
+* PHP 5.3.3+
 * A web server. We prefer nginx.
 * A MySQL server to connect to (doesn't have to be on the same server.)
 * PHPCI needs to be able to run `exec()`, so make sure this is not disabled.


### PR DESCRIPTION
Symfony/YAML requires PHP 5.3.3 (and Composer requires 5.3.2, so there is not a great compatibility loss by the recent switch away from the PECL extension for YAML).
