### PR TITLE
Phpunit comment tweak

### DIFF
--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -4,9 +4,13 @@ namespace PHPCI\Plugin;
 
 class PhpUnit implements \PHPCI\Plugin
 {
-	protected $directory;
 	protected $args;
 	protected $phpci;
+
+	/**
+	 * @var string|string[] $directory The directory (or array of dirs) to run PHPUnit on
+	 */
+	protected $directory;
 	
 	/**
 	 * @var string $runFrom When running PHPUnit with an XML config, the command is run from this directory
@@ -14,7 +18,7 @@ class PhpUnit implements \PHPCI\Plugin
 	protected $runFrom;
 
 	/**
-	 * @var string $xmlConfigFile The path of an xml config for PHPUnit
+	 * @var string|string[] $xmlConfigFile The path (or array of paths) of an xml config for PHPUnit
 	 */
 	protected $xmlConfigFile;
 


### PR DESCRIPTION
Small change to the comments in the PHPUnit plugin to make it explicit that the paths and config file can be arrays.
