### PR TITLE
Add Unit testing to PHPCI

### DIFF
--- a/Tests/PHPCI/Plugin/PHPUnitTest.php
+++ b/Tests/PHPCI/Plugin/PHPUnitTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace PHPCI\Plugin\Tests;
+
+use PHPCI\Plugin\PHPUnit;
+
+define('PHPCI_BIN_DIR', "FAKEPHPCIBIN");
+
+class PHPUnitTest
+	extends  \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @var PHPUnit $testedPhpUnit
+	 */
+	protected $testedPhpUnit;
+
+	/**
+	 * @var \PHPUnit_Framework_MockObject_MockObject $mockCiBuilder
+	 */
+	protected $mockCiBuilder;
+
+	public function setUp()
+	{
+		$this->mockCiBuilder = $this->getMock(
+			'\PHPCI\Builder',
+			array(),
+			array(),
+			"mockBuilder",
+			false
+		);
+		$this->mockCiBuilder->buildPath = "/";
+
+		$this->loadPhpUnitWithOptions();
+	}
+
+	protected function loadPhpUnitWithOptions($arrOptions = array())
+	{
+		$this->testedPhpUnit = new PHPUnit($this->mockCiBuilder, $arrOptions);
+	}
+
+	/**
+	 * @covers PHPUnit::execute
+	 */
+	public function testExecute_ReturnsTrueWithoutArgs()
+	{
+		$returnValue = $this->testedPhpUnit->execute();
+		$expectedReturn = true;
+
+		$this->assertEquals($expectedReturn, $returnValue);
+	}
+
+	/**
+	 * @covers PHPUnit::execute
+	 * @covers PHPUnit::runDir
+	 */
+	public function testExecute_CallsExecuteCommandOnceWhenGivenStringDirectory()
+	{
+		chdir('/');
+
+		$this->loadPhpUnitWithOptions(array(
+			'directory'	=> "Fake/Test/Path"
+		));
+
+		$this->mockCiBuilder->expects($this->once())->method("executeCommand");
+
+		$returnValue = $this->testedPhpUnit->execute();
+	}
+
+	/**
+	 * @covers PHPUnit::execute
+	 * @covers PHPUnit::runConfigFile
+	 */
+	public function testExecute_CallsExecuteCommandOnceWhenGivenStringConfig()
+	{
+		chdir('/');
+
+		$this->loadPhpUnitWithOptions(array(
+			'config'	=> "Fake/Test/config.xml"
+		));
+
+		$this->mockCiBuilder->expects($this->once())->method("executeCommand");
+
+		$returnValue = $this->testedPhpUnit->execute();
+	}
+
+	/**
+	 * @covers PHPUnit::execute
+	 * @covers PHPUnit::runDir
+	 */
+	public function testExecute_CallsExecuteCommandManyTimesWhenGivenArrayDirectory()
+	{
+		chdir('/');
+
+		$this->loadPhpUnitWithOptions(array(
+			'directory'	=> array(0, 1)
+		));
+
+		$this->mockCiBuilder->expects($this->at(0))->method("executeCommand");
+		$this->mockCiBuilder->expects($this->at(1))->method("executeCommand");
+
+		$returnValue = $this->testedPhpUnit->execute();
+	}
+
+	/**
+	 * @covers PHPUnit::execute
+	 * @covers PHPUnit::runConfigFile
+	 */
+	public function testExecute_CallsExecuteCommandManyTimesWhenGivenArrayConfig()
+	{
+		chdir('/');
+
+		$this->loadPhpUnitWithOptions(array(
+			'config'	=> array(0, 1)
+		));
+
+		$this->mockCiBuilder->expects($this->at(0))->method("executeCommand");
+		$this->mockCiBuilder->expects($this->at(1))->method("executeCommand");
+
+		$returnValue = $this->testedPhpUnit->execute();
+	}
+
+}


### PR DESCRIPTION
I've started writing some unit tests for PHPCI. It seems to me that this is a good point to start getting the coverage up. If we want to start doing some larger refactorings then it will really help.

I'm undecided if the directory structure is sensible.
