### PR TITLE
Fixed GitHub remote build of private repo via SSH

### DIFF
--- a/PHPCI/Model/Build/RemoteGitBuild.php
+++ b/PHPCI/Model/Build/RemoteGitBuild.php
@@ -76,7 +76,7 @@ abstract class RemoteGitBuild extends Build
         chmod($keyFile, 0600);
 
         // Use the key file to do an SSH clone:
-        $cmd = 'ssh-agent ssh-add "%s" && git clone -b %s %s "%s" && ssh-agent -k';
+        $cmd = 'eval `ssh-agent -s` && ssh-add "%s" && git clone -b %s %s "%s" && ssh-agent -k';
         $success = $builder->executeCommand($cmd, $keyFile, $this->getBranch(), $this->getCloneUrl(), $to);
         
         // Remove the key file:


### PR DESCRIPTION
The way `ssh-agent` was being used was causing the required `SSH_*` environment variables not to be set in my (and probably everyone's) environment.  You must `eval()` the output of `ssh-agent -s` to create the variables, then `ssh-add` and `ssh-agent -k` will use them to connect to the running agent.
