### PR TITLE
MySQL import file feature

### DIFF
--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -91,7 +91,7 @@ class Mysql implements \PHPCI\Plugin
             throw new \Exception("Import statement must contiain an 'file' key");
         }
         
-        $import_file = $this->phpci->buildPath . '/' . $query['file'];
+        $import_file = $this->phpci->buildPath . $query['file'];
         if (!is_readable($import_file)) {
         	throw new \Exception("Cannot open SQL import file: $import_file");
         }


### PR DESCRIPTION
I've added a feature to my fork that allows you to specify a file to be imported by mysql.  I use this feature to load a test database before testing.  Here is the syntax:

```
setup:
    mysql:
        - "DROP DATABASE IF EXISTS phpunit_test_myapp;"
        - "CREATE DATABASE phpunit_test_myapp;"
        - "GRANT ALL PRIVILEGES ON phpunit_test_myapp.* TO phpunit_tester@'localhost' IDENTIFIED BY 'phpunit';"

        # Import/execute a file, note that files are relative to the build dir
        - import: { file: "data/myapp.sql" }

        # Chances are good that you need to specify the database name, do it like this:
        - import: { file: "data/myapp.sql", database: phpunit_test_myapp }

        # You can even import GZIP and BZIP2 compressed files if they end in .gz or .bz2:
        - import: { file: "data/myapp.sql.gz", database: phpunit_test_myapp }

        # Queries are run in order, so you can have more queries later:
        - "INSERT INTO user (username, password) VALUES ('foo', 'bar');"
```

This is done via the shell, which means Windows will not be well supported, but I don't think this represents a security risk since the specified file is passed to MySQL via STDOUT/STDIN and the MySQL client is running under the specified privileges.  It would be cool to do this in PDO directly, but I imagine that will be tricky.
