### PR TITLE
Added ability to use custom PHPUnit installation during testing

### DIFF
--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -92,17 +92,19 @@ class PhpUnit implements \PHPCI\Plugin
         if (is_array($configPath)) {
             return $this->recurseArg($configPath, array($this, "runConfigFile"));
         } else {
+            
+            $curdir = getcwd();
+            
             if ($this->runFrom) {
-                $curdir = getcwd();
                 chdir($this->phpci->buildPath.'/'.$this->runFrom);
+            } else {
+                chdir($this->phpci->buildPath.'/'.dirname($configPath));
             }
 
             $cmd = $this->phpunit_cmd . ' %s -c "%s"';
             $success = $this->phpci->executeCommand($cmd, $this->args, $this->phpci->buildPath . $configPath);
             
-            if ($this->runFrom) {
-                chdir($curdir);
-            }
+            chdir($curdir);
 
             return $success;
         }


### PR DESCRIPTION
I use some non standard PHPUnit extensions (like the Selenium extension), and so for my projects, in PHPCI, I use composer to install PHPUnit and the custom extensions, then I can use this updated feature to use my version of PHPUnit instead of the server's version.

Syntax:

```
php_unit:
    config:
        - "protected/tests/phpunit.xml.dist"
    # Using PHPUnit from Composer since it has the Selenium extension
    phpunit_cmd: "protected/vendors/phpunit/phpunit/phpunit.php"
```

Note that this command will be escaped to prevent shell command injection, prepended with the current build dir, and the entire thing will be passed to the `php` command, so it should be relatively safe.

Basically, from my example above, the executed command for me would be:
`php '/opt/PHPCI/build/project3-build79/protected/vendors/phpunit/phpunit/phpunit.php'  -c "/opt/PHPCI/build/project3-build79/protected/tests/phpunit.xml.dist"`
