### PR TITLE
This should be checking the value not the key

### DIFF
--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -66,7 +66,7 @@ class PhpCsFixer implements \PHPCI\Plugin
             $this->args .= ' --diff';
         }
 
-        if ( array_key_exists('level', $options) && array_key_exists($options['level'], $this->levels) )
+        if ( array_key_exists('level', $options) && in_array($options['level'], $this->levels) )
         {
             $this->level = $options['level'];
             $this->args .= ' --level='.$options['level'];


### PR DESCRIPTION
Currently looks for key not value, as the array for levels is unkeyed this will result in the level never being used
