### PR TITLE
Add support for bare repositories

### DIFF
--- a/PHPCI/Model/Build/LocalBuild.php
+++ b/PHPCI/Model/Build/LocalBuild.php
@@ -37,7 +37,7 @@ class LocalBuild extends Build
             if($gitConfig["core"]["bare"]) {
                 // Looks like we're right. We need to extract the archive!
                 $guid = uniqid();
-                $builder->executeCommand('mkdir "/tmp/%s" && git archive master | tar -x -C "/tmp/%s"', $guid, $guid);
+                $builder->executeCommand('mkdir "/tmp/%s" && git --git-dir="%s" archive master | tar -x -C "/tmp/%s"', $guid, $reference, $guid);
                 $reference = '/tmp/'.$guid;
             }
         }


### PR DESCRIPTION
This request addresses the issue where if the project is a bare repository, we won't be able to run tests or look at the build config.
