### PR TITLE
Extended phpcs plugin to allow for extra commandline arguments.

### DIFF
--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -26,6 +26,8 @@ class PhpCodeSniffer implements \PHPCI\Plugin
         $this->phpci        = $phpci;
         $this->directory    = isset($options['directory']) ? $options['directory'] : $phpci->buildPath;
         $this->standard     = isset($options['standard']) ? $options['standard'] : 'PSR2';
+        $this->tab_width    = isset($options['tab_width']) ? $options['tab_width'] : '';
+        $this->encoding     = isset($options['encoding']) ? $options['encoding'] : '';
     }
 
     /**
@@ -39,7 +41,27 @@ class PhpCodeSniffer implements \PHPCI\Plugin
             $ignore = ' --ignore=' . implode(',', $this->phpci->ignore);
         }
 
-        $cmd = PHPCI_BIN_DIR . 'phpcs --standard=%s %s "%s"';
-        return $this->phpci->executeCommand($cmd, $this->standard, $ignore, $this->phpci->buildPath);
+        $standard = '';
+
+        if (strpos($this->standard, '/') !== false) {
+            $standard = ' --standard='.$this->directory.$this->standard;
+        } else {
+            $standard = ' --standard='.$this->standard;
+        }
+
+        $tab_width = '';
+
+        if (strlen($this->tab_width)) {
+            $tab_width = ' --tab-width='.$this->tab_width;
+        }
+
+        $encoding = '';
+
+        if (strlen($this->encoding)) {
+            $encoding = ' --encoding='.$this->encoding;
+        }
+
+        $cmd = PHPCI_BIN_DIR . 'phpcs %s %s %s %s "%s"';
+        return $this->phpci->executeCommand($cmd, $standard, $ignore, $tab_width, $encoding, $this->phpci->buildPath);
     }
 }


### PR DESCRIPTION
- Now accepts paths in the --standards argument (and correctly prepends
  the build directory so it actually works)
- Now accepts the --tabwidth argument so that if your project favours tabs
  over spaces you can still just use PSR2 and you don't have to sacrifice
  using the Generic.WhiteSpace.ScopeIndent rule because it is spaces-only
- Now accpets the --encoding argument. I haven't used this before, but
  looking in the phpcs documentation it looks like a very useful one to
  have as most people code in utf-8 but phpcs defaults to iso-8859-1 and
  it can apparently "cause double-encoding problems when generating UTF-8
  encoded XML reports"
