### PR TITLE
Fix rendered build tables

### DIFF
--- a/PHPCI/View/BuildsTable.phtml
+++ b/PHPCI/View/BuildsTable.phtml
@@ -49,9 +49,7 @@ switch($build->getStatus())
 		}
 		if ( 0 === count($plugins) ) {
 			?>
-			<span class='label label-<?= $subcls ?>'>
-				<?= $status ?>
-			</span>
+			<span class='label label-<?= $subcls ?>'><?= $status ?></span>
 			<?php
 		}
 		?>
@@ -59,9 +57,7 @@ switch($build->getStatus())
 			foreach($plugins as $plugin => $pluginstatus):
 				$subcls = $pluginstatus?'label label-success':'label label-important';
 		?>
-			<span class='<?= $subcls ?>'>
-				<?= ucwords(str_replace('_', ' ', $plugin)) ?>
-			</span>
+			<span class='<?= $subcls ?>'><?= ucwords(str_replace('_', ' ', $plugin)) ?></span>
 		<?php endforeach; ?>
 		<br style='clear:both;' />
 	</td>


### PR DESCRIPTION
Build table labels (if a lot of rules were used for a given build) were overflowing weirdly due to whitespace rules in Bootstrap and the 'nice' layout in the view. This change makes the view less nice (see the code) but makes the rendered table much better by not allowing a label to overflow its table cell.
