### PR TITLE
Support local PHPMD rules and suffixes

### DIFF
--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -17,31 +17,57 @@ namespace PHPCI\Plugin;
 */
 class PhpMessDetector implements \PHPCI\Plugin
 {
-    protected $directory;
     /**
-     * Array of PHPMD rules. Possible values: codesize, unusedcode, naming, design, controversial
+     * @var \PHPCI\Builder
+     */
+    protected $phpci;
+
+    /**
+     * @var array
+     */
+    protected $suffixes;
+
+    /**
+     * Array of PHPMD rules. Can be one of the builtins (codesize, unusedcode, naming, design, controversial)
+     * or a filenname (detected by checking for a / in it), either absolute or relative to the project root.
      * @var array
      */
     protected $rules;
 
+    /**
+     * @param \PHPCI\Builder $phpci
+     * @param array $options
+     */
     public function __construct(\PHPCI\Builder $phpci, array $options = array())
     {
-        $this->phpci        = $phpci;
-        $this->rules        = isset($options['rules']) ? (array)$options['rules'] : array('codesize', 'unusedcode', 'naming');
+        $this->phpci = $phpci;
+
+        $this->suffixes = isset($options['suffixes']) ? (array)$options['suffixes'] : array('php');
+
+        $this->rules = isset($options['rules']) ? (array)$options['rules'] : array('codesize', 'unusedcode', 'naming');
+        foreach ($this->rules as &$rule) {
+            if ($rule[0] !== '/' && strpos($rule, '/') !== FALSE) {
+                $rule = $this->phpci->buildPath . $rule;
+            }
+        }
     }
 
     /**
-    * Runs PHP Mess Detector in a specified directory.
-    */
+     * Runs PHP Mess Detector in a specified directory.
+     */
     public function execute()
     {
         $ignore = '';
-        
         if (count($this->phpci->ignore)) {
             $ignore = ' --exclude ' . implode(',', $this->phpci->ignore);
         }
 
-        $cmd = PHPCI_BIN_DIR . 'phpmd "%s" text %s %s';
-        return $this->phpci->executeCommand($cmd, $this->phpci->buildPath, implode(',', $this->rules), $ignore);
+        $suffixes = '';
+        if (count($this->suffixes)) {
+            $suffixes = ' --suffixes ' . implode(',', $this->suffixes);
+        }
+
+        $cmd = PHPCI_BIN_DIR . 'phpmd "%s" text %s %s %s';
+        return $this->phpci->executeCommand($cmd, $this->phpci->buildPath, implode(',', $this->rules), $ignore, $suffixes);
     }
 }


### PR DESCRIPTION
Allows to specify rules as a relative path in the project.

The suffixes to scan can be given in options now, default is just php.
