### PR TITLE
Added initial version of the PHP parallel lint plugin.

### DIFF
--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -1,0 +1,42 @@
+<?php
+/**
+* PHPCI - Continuous Integration for PHP
+*
+* @copyright    Copyright 2013, Block 8 Limited.
+* @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+* @link         http://www.phptesting.org/
+*/
+
+namespace PHPCI\Plugin;
+
+/**
+* Php Parallel Lint Plugin - Provides access to PHP lint functionality.
+* @author       Vaclav Makes <vaclav@makes.cz>
+* @package      PHPCI
+* @subpackage   Plugins
+*/
+class PhpParallelLint implements \PHPCI\Plugin
+{
+    protected $directory;
+    protected $preferDist;
+    protected $phpci;
+
+    public function __construct(\PHPCI\Builder $phpci, array $options = array())
+    {
+        $path               = $phpci->buildPath;
+        $this->phpci        = $phpci;
+        $this->directory    = isset($options['directory']) ? $path . $options['directory'] : $path;
+    }
+
+    /**
+    * Executes parallel lint
+    */
+    public function execute()
+    {
+        // build the parallel lint command
+        $cmd = "run %s";
+
+        // and execute it
+        return $this->phpci->executeCommand(PHPCI_BIN_DIR . $cmd, $this->directory);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "fabpot/php-cs-fixer"      : "0.3.*@dev",
         "swiftmailer/swiftmailer"  : "v5.0.0",
         "phploc/phploc": "*",
-	    "atoum/atoum":"*"
+        "atoum/atoum":"*",
+        "jakub-onderka/php-parallel-lint": "dev-master"
     }
 }


### PR DESCRIPTION
Added plugin for parallel lint PHP code (recursive _php -l_ on PHP files).

Example for error:

``` PHP
<?php

$configurator = new App\Config\Configurator();
$configurator->run();
ASD
```

On library parallel lint is send pull request for change binary file name (`run` to `parallel-lint`) - https://github.com/JakubOnderka/PHP-Parallel-Lint/pull/8/files.
