### PR TITLE
added extended latin for font

### DIFF
--- a/PHPCI/View/layout.phtml
+++ b/PHPCI/View/layout.phtml
@@ -6,7 +6,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-		<link href='//fonts.googleapis.com/css?family=Roboto:400,100,300,500,700,900,300italic' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=Roboto:400,100,300,500,700,900,300italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 		<link rel="stylesheet" type="text/css" href="<?= PHPCI_URL ?>assets/css/bootstrap.min.css">
 		<link rel="stylesheet" type="text/css" href="<?= PHPCI_URL ?>assets/css/phpci.css">
 		<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>


### PR DESCRIPTION
Added extended latin for _Roboto_ font. Users example from Czech Republic  have names with chars _ěščřžýáíéúů_.

Please, merge this - that is for better usability.
