### PR TITLE
Added leading slash to closure to prevent reference to PHPCI namespace

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -97,7 +97,7 @@ class Builder
     * @param \PHPCI\Model\Build
     * @param callable
     */
-    public function __construct(Build $build, Closure $logCallback)
+    public function __construct(Build $build, \Closure $logCallback)
     {
         $this->build = $build;
         $this->store = Store\Factory::getStore('Build');


### PR DESCRIPTION
Don't forget to put \ in front of PHP namespaced objects or you end up in your own namespace.

In reference to commit: https://github.com/Block8/PHPCI/commit/53993a1add01e2945ae64de787b0634f0c0a10e9
