### PR TITLE
RFC: Configuration to allow running shell plugins

### DIFF
--- a/PHPCI/Plugin/Shell.php
+++ b/PHPCI/Plugin/Shell.php
@@ -44,7 +44,7 @@ class Shell implements \PHPCI\Plugin
     */
     public function execute()
     {
-        if (!defined('ENABLE_SHELL_PLUGIN') && !ENABLE_SHELL_PLUGIN) {
+        if (!defined('ENABLE_SHELL_PLUGIN') || !ENABLE_SHELL_PLUGIN) {
             throw new \Exception('The shell plugin is not enabled.');
         }
 

--- a/vars.php
+++ b/vars.php
@@ -18,7 +18,7 @@ if (!defined('PHPCI_BIN_DIR')) {
 
 // Should PHPCI run the Shell plugin?
 if (!defined('ENABLE_SHELL_PLUGIN')) {
-    define('ENABLE_SHELL_PLUGIN', false);
+    define('ENABLE_SHELL_PLUGIN', true);
 }
 
 // If this is not already defined, we're not running in the console:


### PR DESCRIPTION
This is actually a request for comments how this should be done... I read the discussion about shell plugins and people were thinking this should not be on by default. So:
- Should we create a vars.php.dist so that everyone can modify this?
- Or make installation process to add shell plugin directive to config.yml and use that?
- Something else?
