### PR TITLE
Fixed bug in install php.

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(dirname(__FILE__) . '/../vars.php');
+require_once(dirname(__FILE__) . '/../bootstrap.php');
 
 $installStage = 'start';
 $formAction = '';


### PR DESCRIPTION
install.php requires bootstrap.php instead of vars.php because otherwise
`$config` won't be set in vars.php.

This fixes: Fatal error: Call to a member function get() on a non-object
in /var/www/vars.php on line 11
