### PR TITLE
Bugfix for bare "Local Path" repositories

### DIFF
--- a/PHPCI/Model/Build/LocalBuild.php
+++ b/PHPCI/Model/Build/LocalBuild.php
@@ -33,7 +33,7 @@ class LocalBuild extends Build
         // If there's a /config file in the reference directory, it is probably a bare repository
         // which we'll extract into our build path directly.
         if (is_file($reference.'/config') && $this->handleBareRepository($builder, $reference, $buildPath) === true) {
-            return true;
+            return $this->handleConfig($builder, $buildPath) !== false;
         }
 
         $buildSettings = $this->handleConfig($builder, $reference);
@@ -57,7 +57,7 @@ class LocalBuild extends Build
 
         // If it is indeed a bare repository, then extract it into our build path:
         if ($gitConfig['core']['bare']) {
-            $builder->executeCommand('git --git-dir="%s" archive master | tar -x -C "%s"', $reference, $buildPath);
+            $builder->executeCommand('mkdir %2$s; git --git-dir="%1$s" archive master | tar -x -C "%2$s"', $reference, $buildPath);
             return true;
         }
 


### PR DESCRIPTION
If a project is configured as hosted in "Local Path" and the repository is bare, the build process
does not create a folder to contain the working tree, causing the tar extraction to fail This is fixed by
adding a mkdir-command.

The configuration file was never loaded for bare repositories, causing every build to fail (Builder::$config
was null and array_key_exists failed in Builder.php). Calling handleConfig after extracting the repository fixed the problem.

Tested on Debian 7.1 using Apache 2 (with and without phpci.yml-file).
