### PR TITLE
Fixed LoggedBuildContextTidier (replace "build" object with "buildID")

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -249,7 +249,7 @@ class Builder implements LoggerAwareInterface
 
         // The build is added to the context so the logger can use
         // details from it if required.
-        $context['build'] = $this;
+        $context['build'] = $this->build;
 
         foreach ($message as $item) {
             $this->logger->log($level, $item, $context);

--- a/PHPCI/Helper/LoggedBuildContextTidier.php
+++ b/PHPCI/Helper/LoggedBuildContextTidier.php
@@ -2,9 +2,10 @@
 
 namespace PHPCI\Helper;
 
+use PHPCI\Model\Build;
 
-class LoggedBuildContextTidier{
-
+class LoggedBuildContextTidier
+{
     function __invoke()
     {
         return $this->tidyLoggedBuildContext(func_get_arg(0));


### PR DESCRIPTION
Fixed instanceof comparison (wrong namespace) and add correct object to 'build' context in logger. 

It now correctly replaces the 'build' context in log entries, preventing logs to be unreadable.

Before:

```
[2013-11-12 22:17:59] BuildLog.INFO: RUNNING PLUGIN: php_code_sniffer {"build":"[object] (PHPCI\\Builder: {\"buildPath\":\"/home/elkangaroo/dev/workspace/php/PHPCI/PHPCI/../build/project1-build7/\",\"ignore\":[\"cache\",\"config\",\"dev\",\"vendor\"],\"quiet\":false})"} []
[2013-11-12 22:18:12] BuildLog.INFO: PLUGIN STATUS: SUCCESS! {"build":"[object] (PHPCI\\Builder: {\"buildPath\":\"/home/elkangaroo/dev/workspace/php/PHPCI/PHPCI/../build/project1-build7/\",\"ignore\":[\"cache\",\"config\",\"dev\",\"vendor\"],\"quiet\":false})"} []
```

After:

```
[2013-11-12 23:16:50] RunCommand.INFO: RUNNING PLUGIN: php_code_sniffer {"buildID":"11"} []
[2013-11-12 23:17:05] RunCommand.INFO: PLUGIN STATUS: SUCCESS! {"buildID":"11"} []
```
