### PR TITLE
Update install.php

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -93,7 +93,7 @@ if ($installOK && strtoupper($_SERVER['REQUEST_METHOD']) == 'POST') {
         unset($config['tmp']);
 
         $dumper = new \Symfony\Component\Yaml\Dumper();
-        $yaml = $dumper->dump($config);
+        $yaml = $dumper->dump($config, 5);
 
         file_put_contents(PHPCI_DIR . 'PHPCI/config.yml', $yaml);
 


### PR DESCRIPTION
"Pretty printing" `config.yml` in order to make it editable by humans. `5` is just value which is looking good for me. It produces a `config.yml` like this:

```
prevstage:
    - start
    - database
    - github
    - email
b8:
    database:
        servers:
            read:
                - localhost
            write:
                - localhost
        name: phpci
        username: *****
        password: *****
phpci:
    url: 'http://phpci.my.org'
    github:
        id: ''
        secret: ''
    email_settings:
        smtp_address: ''
        smtp_port: ''
        smtp_encryption: on
        smtp_username: ''
        smtp_password: ''
        from_address: ''
        default_mailto_address: ''
```

I guess the `prevstage` node can be replaced before writing? If yes I'll prepare that.
