### PR TITLE
Fixed counting (errors, warnings) in PHP Code Sniffer plugin

### DIFF
--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -120,7 +120,7 @@ class PhpCodeSniffer implements \PHPCI\Plugin
             return false;
         }
 
-        $cmd = $phpcs . ' %s %s %s %s %s "%s"';
+        $cmd = $phpcs . ' --report=emacs %s %s %s %s %s "%s"';
         $success = $this->phpci->executeCommand(
             $cmd,
             $standard,
@@ -134,12 +134,12 @@ class PhpCodeSniffer implements \PHPCI\Plugin
         $output = $this->phpci->getLastOutput();
 
         $matches = array();
-        if (preg_match_all('/WARNING/', $output, $matches)) {
+        if (preg_match_all('/\: warning \-/', $output, $matches)) {
             $this->build->storeMeta('phpcs-warnings', count($matches[0]));
         }
 
         $matches = array();
-        if (preg_match_all('/ERROR/', $output, $matches)) {
+        if (preg_match_all('/\: error \-/', $output, $matches)) {
             $this->build->storeMeta('phpcs-errors', count($matches[0]));
         }
 


### PR DESCRIPTION
- fix counting of warnings and errors in PHPCI\Plugin\PhpCodeSniffer
- use --report=emacs for phpcs command in PHPCI\Plugin\PhpCodeSniffer

The PhpCodeSniffer plugin did count warnings & errors incorrectly.
It did count the words "ERROR" (or "WARNING"), while those were repeated 2-3 times for each error/warning within the default report, i.e. _phpcs --report=full_.

The PhpCodeSniffer now uses the _phpcs --report=emacs_ command line flag, which is also more compact and does not bloat the log so much.

Before: 

```
$ /home/elkangaroo/dev/workspace/php/PHPCI/vendor/bin/phpcs  --standard=PSR1  --extensions=php .

FILE: ...me/elkangaroo/dev/workspace/php/whatsthatgame.git/lib/SplAutoloader.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 7 | ERROR | Each class must be in a namespace of at least one level (a
   |       | top-level vendor name)
--------------------------------------------------------------------------------
```

After:

```
$ /home/elkangaroo/dev/workspace/php/PHPCI/vendor/bin/phpcs  --standard=PSR1  --extensions=php  --report=emacs .

/home/elkangaroo/dev/workspace/php/whatsthatgame.git/lib/SplAutoloader.php:7:1: error - Each class must be in a namespace of at least one level (a top-level vendor name)
```
