### PR TITLE
Move shell command execution out of builder into separate class and fix issue #218

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -217,7 +217,7 @@ class Builder implements LoggerAwareInterface, BuildLogger
      */
     public function executeCommand()
     {
-        return $this->commandExecutor->executeCommand(func_get_args());
+        return $this->commandExecutor->buildAndExecuteCommand(func_get_args());
     }
 
     /**

--- a/PHPCI/Helper/CommandExecutor.php
+++ b/PHPCI/Helper/CommandExecutor.php
@@ -48,11 +48,21 @@ class CommandExecutor
     }
 
     /**
+     * Executes shell commands. Accepts multiple arguments the first
+     * is the template and everything else is inserted in. c.f. sprintf
+     * @return bool Indicates success
+     */
+    public function executeCommand()
+    {
+        return $this->buildAndExecuteCommand(func_get_args());
+    }
+
+    /**
      * Executes shell commands.
      * @param array $args
      * @return bool Indicates success
      */
-    public function executeCommand($args = array())
+    public function buildAndExecuteCommand($args = array())
     {
         $this->lastOutput = array();
 

--- a/Tests/PHPCI/Helper/CommandExecutorTest.php
+++ b/Tests/PHPCI/Helper/CommandExecutorTest.php
@@ -21,28 +21,28 @@ class CommandExecutorTest extends ProphecyTestCase
 
     public function testGetLastOutput_ReturnsOutputOfCommand()
     {
-        $this->testedExecutor->executeCommand(array('echo "%s"', 'Hello World'));
+        $this->testedExecutor->buildAndExecuteCommand(array('echo "%s"', 'Hello World'));
         $output = $this->testedExecutor->getLastOutput();
         $this->assertEquals("Hello World", $output);
     }
 
     public function testGetLastOutput_ForgetsPreviousCommandOutput()
     {
-        $this->testedExecutor->executeCommand(array('echo "%s"', 'Hello World'));
-        $this->testedExecutor->executeCommand(array('echo "%s"', 'Hello Tester'));
+        $this->testedExecutor->buildAndExecuteCommand(array('echo "%s"', 'Hello World'));
+        $this->testedExecutor->buildAndExecuteCommand(array('echo "%s"', 'Hello Tester'));
         $output = $this->testedExecutor->getLastOutput();
         $this->assertEquals("Hello Tester", $output);
     }
 
     public function testExecuteCommand_ReturnsTrueForValidCommands()
     {
-        $returnValue = $this->testedExecutor->executeCommand(array('echo "%s"', 'Hello World'));
+        $returnValue = $this->testedExecutor->buildAndExecuteCommand(array('echo "%s"', 'Hello World'));
         $this->assertTrue($returnValue);
     }
 
     public function testExecuteCommand_ReturnsFalseForInvalidCommands()
     {
-        $returnValue = $this->testedExecutor->executeCommand(array('eerfdcvcho "%s"', 'Hello World'));
+        $returnValue = $this->testedExecutor->buildAndExecuteCommand(array('eerfdcvcho "%s"', 'Hello World'));
         $this->assertFalse($returnValue);
     }
 


### PR DESCRIPTION
The builder class is quite large and this in my first step at breaking it down a bit. It should make it a bit easier to unit test. At the same time I've fixed issue #218 as it was quite straight forward to do whilst extracting the execution code.
