### PR TITLE
adding support for the 'committer' parameter

### DIFF
--- a/PHPCI/Command/PollCommand.php
+++ b/PHPCI/Command/PollCommand.php
@@ -75,6 +75,7 @@ class PollCommand extends Command
             $commits = $http->get('/repos/' . $project->getReference() . '/commits', array('access_token' => $token));
 
             $last_commit = $commits['body'][0]['sha'];
+            $last_committer = $commits['body'][0]['commit']['committer']['email'];
 
             $this->logger->info("Last commit to github for " . $project->getTitle() . " is " . $last_commit);
 
@@ -87,7 +88,9 @@ class PollCommand extends Command
                 $build->setStatus(Build::STATUS_NEW);
                 $build->setBranch($project->getType() === 'hg' ? 'default' : 'master');
                 $build->setCreated(new \DateTime());
-
+                if (!empty($last_committer)) {
+                    $build->setCommitterEmail($last_committer);
+                }
                 $buildStore->save($build);
 
                 $project->setLastCommit($last_commit);


### PR DESCRIPTION
adding support for the committer parameter in the email configuration section of phpci.yaml

enabled with
committer: true
in your phpci.yml

this change will enable the email to be sent to the committer
