### PR TITLE
When phpci is default, it should be used.

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -101,8 +101,8 @@ if ($installOK && strtoupper($_SERVER['REQUEST_METHOD']) == 'POST') {
          * Create database:
          */
         $dbhost = $config['b8']['database']['servers']['write'][0];
-        $dbname = $config['b8']['database']['name'];
-        $dbuser = $config['b8']['database']['username'];
+        $dbname = $config['b8']['database']['name'] ?: 'phpci';
+        $dbuser = $config['b8']['database']['username'] ?: 'phpci';
         $dbpass = $config['b8']['database']['password'];
 
         $pdo = new PDO('mysql:host=' . $dbhost, $dbuser, $dbpass);


### PR DESCRIPTION
The installer displays `phpci` as placeholders for the database settings (database and username).

When I do not change them the installer fails with this error:

`Fatal error: Uncaught exception 'PDOException' with message 'SQLSTATE[3D000]: Invalid catalog name: 1046 No database selected' in /Users/tobias/Sites/PHPCI/vendor/block8/b8framework/b8/Database/Map.php on line 40`

I assume it is simply because they are not set. This pull requests uses the given values, or phpci as default.

In theory I would assume all the configuration values should be checked somehow. Is this just not implemented, or is it not desired?
