### PR TITLE
Redirect after installation is broken

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -139,7 +139,7 @@ if ($installOK && strtoupper($_SERVER['REQUEST_METHOD']) == 'POST') {
             $store->save($user);
         }
 
-        $formAction = '/session/login';
+        $formAction = rtrim( $config['phpci']['url'], '/' ) . '/session/login';
     }
 }
 


### PR DESCRIPTION
Currently the form just redirects to `/session/login`, which is wrong if PHPCI was installed into a subdirectory. 

This pull request fixes the URL that is used in the last form step.
