### PR TITLE
Fixed: Array access for $config

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -82,6 +82,11 @@ if ($installOK && strtoupper($_SERVER['REQUEST_METHOD']) == 'POST') {
         require_once(PHPCI_DIR . 'vendor/autoload.php');
 
         /**
+         *  Temporary save phpci URL for redirect after install ($config is replaced in bootstrap.php)
+         */
+        $phpciUrl = $config['phpci']['url'];
+
+        /**
          * Write config file:
          */
         $config['b8']['database']['servers']['read'] = array($config['b8']['database']['servers']['read']);
@@ -139,7 +144,7 @@ if ($installOK && strtoupper($_SERVER['REQUEST_METHOD']) == 'POST') {
             $store->save($user);
         }
 
-        $formAction = rtrim( $config['phpci']['url'], '/' ) . '/session/login';
+        $formAction = rtrim( $phpciUrl, '/' ) . '/session/login';
     }
 }
 


### PR DESCRIPTION
$config in install.php line 142 is already an object created in bootstrap (lines 54-57)
That results in Fatal error "Cannot use object of type b8\Config as array"
https://www.dropbox.com/s/uz2wnlydhdqqjex/Screenshot%202014-02-04%2022.59.50.png
