### PR TITLE
Fixed: Project output page with gitlab

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -210,7 +210,7 @@ class ProjectController extends \PHPCI\Controller
             $values['key']  = $values['git_key'];
 
             if ($values['type'] == "gitlab") {
-                $accessInfo = $project->getAccessInformation();
+                $accessInfo = unserialize($project->getAccessInformation());
                 $reference = $accessInfo["user"].'@'.$accessInfo["domain"].':' . $project->getReference().".git";
                 $values['reference'] = $reference;
             }


### PR DESCRIPTION
If chosen gitlab hosting type for project, edit project page has these errors, because there is no unserialize:

``` php
Warning: Illegal string offset 'user' in PHPCI/Controller/ProjectController.php on line 214
Warning: Illegal string offset 'domain' in PHPCI/Controller/ProjectController.php on line 214
```
