### PR TITLE
Cross-platform safe copy in Plugin.CopyBuild

### DIFF
--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -43,7 +43,7 @@ class CopyBuild implements \PHPCI\Plugin
             return false;
         }
 
-        $cmd = 'mkdir -p "%s" && ls -1a "%s"* | xargs -r -t "%s/"';
+        $cmd = 'mkdir -p "%s" && cp -R "%s" "%s"';
         $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory);
 
         if ($this->ignore) {


### PR DESCRIPTION
**Aims to solve inability to use CopyBuild plugin on BSD machines**

Rather than using `xargs` which behaves differently on BSD and Linux, it's safer to use the straight `cp`. We lose the output of which files were copied - but I'd be more than happy to add this as a separate command to list which files were copied and which were ignored.
