### PR TITLE
Preserve absolute paths in Plugin.PhpMessDetector

### DIFF
--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -32,7 +32,8 @@ class PhpMessDetector implements \PHPCI\Plugin
 
     /**
      * @var string, based on the assumption the root may not hold the code to be
-     * tested, exteds the base path
+     * tested, exteds the base path only if the provided path is relative. Absolute
+     * paths are used verbatim
      */
     protected $path;
 
@@ -97,11 +98,16 @@ class PhpMessDetector implements \PHPCI\Plugin
             $this->phpci->logFailure('Could not find phpmd.');
             return false;
         }
+        
+        $path = $this->phpci->buildPath . $this->path;
+        if ($this->path{0} == '/') {
+            $path = $this->path;
+        }
 
         $cmd = $phpmd . ' "%s" text %s %s %s';
         $success = $this->phpci->executeCommand(
             $cmd,
-            $this->phpci->buildPath . $this->path,
+            $path,
             implode(',', $this->rules),
             $ignore,
             $suffixes


### PR DESCRIPTION
Before: all paths, including absolute paths, were treated relative to build directory.

After: any absolute path is not prefixed with the build directory path; it gets used as-is.
