### PR TITLE
Interpolate PHPUnit arguments

### DIFF
--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -101,7 +101,7 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         }
 
         if (isset($options['args'])) {
-            $this->args = $options['args'];
+            $this->args = $this->phpci->interpolate($options['args']);
         }
 
         if (isset($options['path'])) {


### PR DESCRIPTION
Piped PHPUnit plugins args through BuildInterpolator so that build variables are accessible.
