### PR TITLE
Fixed duplicate methods of CommandExecutor helper

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -242,7 +242,7 @@ class Builder implements LoggerAwareInterface
      */
     public function executeCommand()
     {
-        return $this->commandExecutor->buildAndExecuteCommand(func_get_args());
+        return $this->commandExecutor->executeCommand(func_get_args());
     }
 
     /**

--- a/PHPCI/Helper/CommandExecutor.php
+++ b/PHPCI/Helper/CommandExecutor.php
@@ -52,21 +52,11 @@ class CommandExecutor
     }
 
     /**
-     * Executes shell commands. Accepts multiple arguments the first
-     * is the template and everything else is inserted in. c.f. sprintf
-     * @return bool Indicates success
-     */
-    public function executeCommand()
-    {
-        return $this->buildAndExecuteCommand(func_get_args());
-    }
-
-    /**
      * Executes shell commands.
      * @param array $args
      * @return bool Indicates success
      */
-    public function buildAndExecuteCommand($args = array())
+    public function executeCommand($args = array())
     {
         $this->lastOutput = array();
 

--- a/Tests/PHPCI/Helper/CommandExecutorTest.php
+++ b/Tests/PHPCI/Helper/CommandExecutorTest.php
@@ -21,28 +21,28 @@ class CommandExecutorTest extends ProphecyTestCase
 
     public function testGetLastOutput_ReturnsOutputOfCommand()
     {
-        $this->testedExecutor->buildAndExecuteCommand(array('echo "%s"', 'Hello World'));
+        $this->testedExecutor->executeCommand(array('echo "%s"', 'Hello World'));
         $output = $this->testedExecutor->getLastOutput();
         $this->assertEquals("Hello World", $output);
     }
 
     public function testGetLastOutput_ForgetsPreviousCommandOutput()
     {
-        $this->testedExecutor->buildAndExecuteCommand(array('echo "%s"', 'Hello World'));
-        $this->testedExecutor->buildAndExecuteCommand(array('echo "%s"', 'Hello Tester'));
+        $this->testedExecutor->executeCommand(array('echo "%s"', 'Hello World'));
+        $this->testedExecutor->executeCommand(array('echo "%s"', 'Hello Tester'));
         $output = $this->testedExecutor->getLastOutput();
         $this->assertEquals("Hello Tester", $output);
     }
 
     public function testExecuteCommand_ReturnsTrueForValidCommands()
     {
-        $returnValue = $this->testedExecutor->buildAndExecuteCommand(array('echo "%s"', 'Hello World'));
+        $returnValue = $this->testedExecutor->executeCommand(array('echo "%s"', 'Hello World'));
         $this->assertTrue($returnValue);
     }
 
     public function testExecuteCommand_ReturnsFalseForInvalidCommands()
     {
-        $returnValue = $this->testedExecutor->buildAndExecuteCommand(array('eerfdcvcho "%s" > /dev/null 2>&1', 'Hello World'));
+        $returnValue = $this->testedExecutor->executeCommand(array('eerfdcvcho "%s" > /dev/null 2>&1', 'Hello World'));
         $this->assertFalse($returnValue);
     }
 


### PR DESCRIPTION
Fixed duplicate methods of CommandExecutor helper: executeCommand and buildAndExecuteCommand
