### PR TITLE
Issue #434: Clean up all builds

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -96,6 +96,30 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
+    * Delete all builds of a project
+    */
+    public function clean($projectId)
+    {
+        if (empty($_SESSION['user']) || !$_SESSION['user']->getIsAdmin()) {
+            throw new \Exception('You do not have permission to do that.');
+        }
+
+        /* @var \PHPCI\Model\Project $project */
+        $project = $this->projectStore->getById($projectId);
+
+        if (empty($project)) {
+            throw new NotFoundException('Project with id: ' . $projectId . ' not found');
+        }
+        
+        if (!$project->cleanBuilds()) {
+            throw new \Exception('Unable to clean up of builds of project.');
+        }
+
+        header('Location: '.PHPCI_URL.'project/view/' . $projectId);
+        exit;
+    }
+
+    /**
     * Delete a project.
     */
     public function delete($projectId)

--- a/PHPCI/Model/Project.php
+++ b/PHPCI/Model/Project.php
@@ -44,6 +44,28 @@ class Project extends ProjectBase
         return null;
     }
 
+    public function cleanBuilds()
+    {
+        $buildsStore    = Store\Factory::getStore('Build');
+
+        $criteria       = array('project_id' => $this->getId());
+        $builds         = $buildsStore->getWhere($criteria, 0);
+
+        if (is_array($builds['items']) ) {
+            if (count($builds['items'])) {
+                foreach ($builds['items'] as $build) {
+                    if ($build instanceof Build) {
+                        $buildsStore->delete($build);
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        return true;
+    }
+
     public function getAccessInformation($key = null)
     {
         $data = unserialize($this->data['access_information']);

--- a/PHPCI/View/Project/view.phtml
+++ b/PHPCI/View/Project/view.phtml
@@ -12,6 +12,7 @@
                 <a class="list-group-item" href="<?php echo PHPCI_URL ?>project/build/<?php print $project->getId(); ?>"><i class="glyphicon glyphicon-cog"></i> Build Now</a>
 
                 <?php if($this->User()->getIsAdmin()): ?>
+                    <a class="list-group-item" href="#" id="clean-project"><i class="glyphicon glyphicon-refresh"></i> Clean builds</a>
                     <a class="list-group-item" href="<?php echo PHPCI_URL ?>project/edit/<?php print $project->getId(); ?>"><i class="glyphicon glyphicon-edit"></i> Edit Project</a>
                     <a class="list-group-item" href="#" id="delete-project"><i class="glyphicon glyphicon-trash"></i> Delete Project</a>
                 <?php endif; ?>
@@ -117,6 +118,12 @@
             confirmDelete(
                 "<?php echo PHPCI_URL ?>project/delete/<?php print $project->getId(); ?>", "Project"
             ).onCloseConfirmed = function () {window.location = '/'};
+        });
+        $('#clean-project').on('click', function (e) {
+            e.preventDefault();
+            confirmDelete(
+                "<?php echo PHPCI_URL ?>project/clean/<?php print $project->getId(); ?>", "All of builds of project"
+            ).onCloseConfirmed = function () {window.location = '<?php echo PHPCI_URL ?>project/view/<?php print $project->getId(); ?>'};
         });
     })
 </script>


### PR DESCRIPTION
#434

Add a button to the project's options page, that will clean up a project from all of builds, to avoid spending a lot of time to delete each of build manually.
![1400311271886](https://cloud.githubusercontent.com/assets/3306156/3004345/edf626ee-dd93-11e3-9199-75058e91d826.jpg)
