### PR TITLE
Add new XMPP Notification plugin

### DIFF
--- a/PHPCI/Plugin/Xmpp.php
+++ b/PHPCI/Plugin/Xmpp.php
@@ -189,15 +189,11 @@ class XMPP implements \PHPCI\Plugin
          * Send XMPP notification for all recipients
          */
         $cmd = $sendxmpp . "%s -f .sendxmpprc -m %s %s";
-        $recipients = '';
-        foreach($this->recipients as $recipient) {
-            if(!empty($recipients))
-                $recipients .= ' ';
-            $recipients .= $recipient;
-        }
+        $recipients = implode(' ', $this->recipients);
 
         $success = $this->phpci->executeCommand(
                 $cmd, $tls, $message_file, $recipients);
+
         print $this->phpci->getLastOutput();
 
         /*


### PR DESCRIPTION
Add new XMPP notification plugin of successful / failure build. 

You need to have sendxmpp binary in default path (/usr/bin/sendxmpp) for linux 

example configuration :

```
complete:
    xmpp:
        recipients:
            - "recipient1@jabber.org"
            - "recipient2@jabber.org"
        tls: true
        username: "yourxmppaccount@server.com"
        password: "password"
```

Use «server» param name to define another server :

```
complete:
    xmpp:
        recipients:
            - "recipient1@jabber.org"
            - "recipient2@jabber.org"
        tls: true
        username: "yourxmppaccount@server.com"
        password: "password"
        server: "gtalk.google.com"
```

Use «alias» to define one pseudo 

Use «date_format» to define date format (strftime) 
