### PR TITLE
Fixed MailerFactory Helper config email settings.

### DIFF
--- a/PHPCI/Helper/MailerFactory.php
+++ b/PHPCI/Helper/MailerFactory.php
@@ -19,7 +19,7 @@ class MailerFactory
 
     public function __construct($config = null)
     {
-        $this->emailConfig  = isset($config['email_settings']) ?: array();
+        $this->emailConfig  = isset($config['email_settings']) ? $config['email_settings'] : array();
     }
 
     /**


### PR DESCRIPTION
$this->emailConfig was true when $config['email_settings'] was set.
