### PR TITLE
Fixed key in add action when 'ssh-keygen' command is not available

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -159,9 +159,9 @@ class ProjectController extends \PHPCI\Controller
             $sshKey = new SshKey();
             $key = $sshKey->generate();
 
-            $values['key'] = $key['private_key'];
-            $values['pubkey'] = $key['public_key'];
-            $pub = $key['public_key'];
+            $values['key']    = $key ? $key['private_key'] : '';
+            $values['pubkey'] = $key ? $key['public_key'] : '';
+            $pub              = $key ? $key['public_key'] : '';
         }
 
         $form = $this->projectForm($values);


### PR DESCRIPTION
associated ticket: https://github.com/Block8/PHPCI/issues/447
