### PR TITLE
Follow the Link HTTP headers for GitHub repositories request.

### DIFF
--- a/PHPCI/Helper/Github.php
+++ b/PHPCI/Helper/Github.php
@@ -24,6 +24,44 @@ class Github
     }
 
     /**
+     * Make all GitHub requests following the Link HTTP headers.
+     *
+     * @param string $url
+     * @param mixed $params
+     * @param array $results
+     *
+     * @return array
+     */
+    public function makeRecursiveRequest($url, $params, $results=[])
+    {
+        $http = new HttpClient('https://api.github.com');
+        $res = $http->get($url, $params);
+
+        foreach ($res['body'] as $key => $item) {
+
+            $results[] = $item;
+
+        }
+
+        foreach ($res['headers'] as $header) {
+
+            if (preg_match('/^Link: <([^>]+)>; rel="next"/', $header, $r)) {
+
+                $host = parse_url($r[1]);
+
+                parse_str($host['query'], $params);
+                $results = $this->makeRecursiveRequest($host['path'], $params, $results);
+
+                break;
+
+            }
+
+        }
+
+        return $results;
+    }
+
+    /**
      * Get an array of repositories from Github's API.
      */
     public function getRepositories()
@@ -41,12 +79,11 @@ class Github
             $orgs = $this->makeRequest('/user/orgs', array('access_token' => $token));
 
             $params = array('type' => 'all', 'access_token' => $token);
-            $repos = array();
-            $repos['user'] = $this->makeRequest('/user/repos', $params);
-
+            $repos = array('user' => array());
+            $repos['user'] = $this->makeRecursiveRequest('/user/repos', $params);
 
             foreach ($orgs as $org) {
-                $repos[$org['login']] = $this->makeRequest('/orgs/'.$org['login'].'/repos', $params);
+                $repos[$org['login']] = $this->makeRecursiveRequest('/orgs/'.$org['login'].'/repos', $params);
             }
 
             $rtn = array();


### PR DESCRIPTION
We have quite a few private repositories on GitHub, and their API is using pagination with a Link HTTP header. In order to display all of the user's repositories, I made a recursive function using b8\HttpClient.
