### PR TITLE
Dereference symlinks in local builds

### DIFF
--- a/PHPCI/Model/Build/LocalBuild.php
+++ b/PHPCI/Model/Build/LocalBuild.php
@@ -47,6 +47,17 @@ class LocalBuild extends Build
             $cmd = 'cp -Rf "%s" "%s/"';
             if (IS_WIN) {
                 $cmd = 'xcopy /E /Y "%s" "%s/*"';
+            } else {
+                // Check for symlinks in $reference directory, and alter copy command to dereference the symlinks
+                $symlinks = array();
+                exec(
+                    sprintf('ls -lR %s | grep ^l', $reference),
+                    $symlinks
+                );
+
+                if (!empty($symlinks)) {
+                    $cmd = 'cp -LRf "%s" "%s/"';
+                }
             }
             $builder->executeCommand($cmd, $reference, $buildPath);
         }


### PR DESCRIPTION
If a local build contains symlinks, it is possible for the default command `cp -Rf "%s" "%s/"` to fail with the error `cp: cannot create symbolic link`.

To work around this, you can call cp by passing the `-L` flag (or `--dereference`).

Unfortunately, I don't know what the impact of of calling `cp -LRf` compared to `cp -Rf` is on a directory without symlinks, therefore I'm running `ls -lR %s | grep ^l` to first check if any symlinks exist.

I think the priority of this is pretty low - as a general rule I'm using Github and Bitbucket builds, but I came across this issue when setting up a local install so I could begin looking at developing a couple of plugins
