### PR TITLE
resolve issue with undefined variable in Windows

### DIFF
--- a/PHPCI/Model/Build/RemoteGitBuild.php
+++ b/PHPCI/Model/Build/RemoteGitBuild.php
@@ -106,7 +106,9 @@ class RemoteGitBuild extends Build
 
         // Remove the key file and git wrapper:
         unlink($keyFile);
-        unlink($gitSshWrapper);
+        if (!IS_WIN) {
+            unlink($gitSshWrapper);
+        }
 
         return $success;
     }


### PR DESCRIPTION
Resolved the following exception on Windows

```
Exception: Notice: Undefined variable: gitSshWrapper in PHPCI\Model\Build\RemoteGitBuild.php line 109
```
