### PR TITLE
Allow the binary finder to use the project composer.json

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -268,7 +268,7 @@ class Builder implements LoggerAwareInterface
      */
     public function findBinary($binary)
     {
-        return $this->commandExecutor->findBinary($binary);
+        return $this->commandExecutor->findBinary($binary, $this->buildPath);
     }
 
     /**

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -10,6 +10,7 @@
 namespace PHPCI\Helper;
 
 use \PHPCI\Logging\BuildLogger;
+use Psr\Log\LogLevel;
 
 abstract class BaseCommandExecutor implements CommandExecutor
 {
@@ -32,12 +33,17 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
     public $logExecOutput = true;
 
-
     /**
      * The path which findBinary will look in.
      * @var string
      */
     protected $rootDir;
+
+    /**
+     * Current build path
+     * @var string
+     */
+    protected $buildPath;
 
     /**
      * @param BuildLogger $logger
@@ -104,5 +110,68 @@ abstract class BaseCommandExecutor implements CommandExecutor
      * @param string $binary
      * @return null|string
      */
-    abstract public function findBinary($binary);
+    public function findBinary($binary, $buildPath = null) {
+        $binaryPath = null;
+        $composerBin = $this->getComposerBinDir(realpath($buildPath));
+
+        if (is_string($binary)) {
+            $binary = array($binary);
+        }
+
+        foreach ($binary as $bin) {
+            $this->logger->log("Looking for binary: " . $bin, LogLevel::DEBUG);
+
+            if (is_dir($composerBin) && is_file($composerBin.'/'.$bin)) {
+                $this->logger->log("Found in ".$composerBin.": " . $bin, LogLevel::DEBUG);
+                $binaryPath = $composerBin . '/' . $bin;
+                break;
+            }
+
+            if (is_file($this->rootDir . $bin)) {
+                $this->logger->log("Found in root: " . $bin, LogLevel::DEBUG);
+                $binaryPath = $this->rootDir . $bin;
+                break;
+            }
+
+            if (is_file($this->rootDir . 'vendor/bin/' . $bin)) {
+                $this->logger->log("Found in vendor/bin: " . $bin, LogLevel::DEBUG);
+                $binaryPath = $this->rootDir . 'vendor/bin/' . $bin;
+                break;
+            }
+
+            $findCmdResult = $this->findGlobalBinary($bin);
+            if (is_file($findCmdResult)) {
+                $this->logger->log("Found in " . $findCmdResult, LogLevel::DEBUG);
+                $binaryPath = $findCmdResult;
+                break;
+            }
+        }
+        return $binaryPath;
+    }
+
+    /**
+     * Find a binary which is installed globally on the system
+     * @param string $binary
+     * @return null|string
+     */
+    abstract protected function findGlobalBinary($bin);
+
+    /**
+     * Try to load the composer.json file in the building project
+     * If the bin-dir is configured, return the full path to it
+     * @param string $path Current build path
+     * @return string|null
+     */
+    public function getComposerBinDir($path) {
+        if (is_dir($path)) {
+            $composer = $path.'/composer.json';
+            if( is_file($composer) ) {
+                $json = json_decode(file_get_contents($composer));
+                if( isset($json->config->{"bin-dir"}) ) {
+                    return $path.'/'.$json->config->{"bin-dir"};
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/PHPCI/Helper/CommandExecutor.php
+++ b/PHPCI/Helper/CommandExecutor.php
@@ -26,7 +26,8 @@ interface CommandExecutor
     /**
      * Find a binary required by a plugin.
      * @param string $binary
+     * @param string $buildPath the current build path
      * @return null|string
      */
-    public function findBinary($binary);
+    public function findBinary($binary, $buildPath = null);
 }

--- a/PHPCI/Helper/UnixCommandExecutor.php
+++ b/PHPCI/Helper/UnixCommandExecutor.php
@@ -9,45 +9,10 @@
 
 namespace PHPCI\Helper;
 
-use Psr\Log\LogLevel;
-
 class UnixCommandExecutor extends BaseCommandExecutor
 {
-    /**
-     * Find a binary required by a plugin.
-     * @param string $binary
-     * @return null|string
-     */
-    public function findBinary($binary)
+    protected function findGlobalBinary($binary)
     {
-        $binaryPath = null;
-
-        if (is_string($binary)) {
-            $binary = array($binary);
-        }
-
-        foreach ($binary as $bin) {
-            $this->logger->log("Looking for binary: " . $bin, LogLevel::DEBUG);
-
-            if (is_file($this->rootDir . $bin)) {
-                $this->logger->log("Found in root: " . $bin, LogLevel::DEBUG);
-                $binaryPath = $this->rootDir . $bin;
-                break;
-            }
-
-            if (is_file($this->rootDir . 'vendor/bin/' . $bin)) {
-                $this->logger->log("Found in vendor/bin: " . $bin, LogLevel::DEBUG);
-                $binaryPath = $this->rootDir . 'vendor/bin/' . $bin;
-                break;
-            }
-
-            $findCmdResult = trim(shell_exec('which ' . $bin));
-            if (!empty($findCmdResult)) {
-                $this->logger->log("Found in " . $findCmdResult, LogLevel::DEBUG);
-                $binaryPath = $findCmdResult;
-                break;
-            }
-        }
-        return $binaryPath;
+        return trim(shell_exec('which ' . $binary));
     }
 }

--- a/PHPCI/Helper/WindowsCommandExecutor.php
+++ b/PHPCI/Helper/WindowsCommandExecutor.php
@@ -9,45 +9,10 @@
 
 namespace PHPCI\Helper;
 
-use Psr\Log\LogLevel;
-
 class WindowsCommandExecutor extends BaseCommandExecutor
 {
-    /**
-     * Find a binary required by a plugin.
-     * @param string $binary
-     * @return null|string
-     */
-    public function findBinary($binary)
+    protected function findGlobalBinary($binary)
     {
-        $binaryPath = null;
-
-        if (is_string($binary)) {
-            $binary = array($binary);
-        }
-
-        foreach ($binary as $bin) {
-            $this->logger->log("Looking for binary: " . $bin, LogLevel::DEBUG);
-
-            if (is_file($this->rootDir . $bin)) {
-                $this->logger->log("Found in root: " . $bin, LogLevel::DEBUG);
-                $binaryPath = $this->rootDir . $bin;
-                break;
-            }
-
-            if (is_file($this->rootDir . 'vendor/bin/' . $bin)) {
-                $this->logger->log("Found in vendor/bin: " . $bin, LogLevel::DEBUG);
-                $binaryPath = $this->rootDir . 'vendor/bin/' . $bin;
-                break;
-            }
-
-            $findCmdResult = trim(shell_exec('where ' . $bin));
-            if (!empty($findCmdResult)) {
-                $this->logger->log("Found in " . $findCmdResult, LogLevel::DEBUG);
-                $binaryPath = $findCmdResult;
-                break;
-            }
-        }
-        return $binaryPath;
+        return trim(shell_exec('where ' . $binary));
     }
 }


### PR DESCRIPTION
- Load JSON file and get bin-dir value: https://getcomposer.org/doc/articles/vendor-binaries.md
- Update finder behaviour to avoid code duplication

With this update, if the project define its own binaries, they are used as default and PHPCI is not the referer for theses files.
