### PR TITLE
Update Behat plugin to be compatible with Behat 3

### DIFF
--- a/PHPCI/Plugin/Behat.php
+++ b/PHPCI/Plugin/Behat.php
@@ -56,7 +56,7 @@ class Behat implements \PHPCI\Plugin
             return false;
         }
 
-        $success = $this->phpci->executeCommand($behat . ' --no-time --format="failed" %s', $this->features);
+        $success = $this->phpci->executeCommand($behat . ' %s', $this->features);
         chdir($curdir);
 
         return $success;


### PR DESCRIPTION
These options are not required, removing them make the plugin work with Behat 3.

Fixes https://github.com/Block8/PHPCI/issues/480
