### PR TITLE
Checkout revision silently

### DIFF
--- a/PHPCI/Model/Build/RemoteGitBuild.php
+++ b/PHPCI/Model/Build/RemoteGitBuild.php
@@ -119,11 +119,13 @@ class RemoteGitBuild extends Build
         $commit = $this->getCommitId();
 
         if (!empty($commit) && $commit != 'Manual') {
-            $cmd = 'cd "%s" && git checkout %s';
+            $cmd = 'cd "%s"';
 
             if (IS_WIN) {
-                $cmd = 'cd /d "%s" && git checkout %s';
+                $cmd = 'cd /d "%s"';
             }
+
+            $cmd .= ' && git checkout %s --quiet';
 
             $success = $builder->executeCommand($cmd, $cloneTo, $this->getCommitId());
         }


### PR DESCRIPTION
When checkouting a specific revision, the cron standard error output gets this message :

```
Note: checking out 'fe0fcd1b79f0db3d49fe6e50765bcb527e29980b'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

...
```

Adding the `--quiet` parameter fixes this.
