### PR TITLE
Set public status page default to OFF

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -356,7 +356,7 @@ class ProjectController extends \PHPCI\Controller
         $field->setLabel('Enable public status page and image for this project?');
         $field->setContainerClass('form-group');
         $field->setCheckedValue(1);
-        $field->setValue(1);
+        $field->setValue(0);
         $form->addField($field);
 
         $field = new Form\Element\Submit();


### PR DESCRIPTION
I turned the public status page default to OFF; I believe it should be an opt-in feature (for privacy reasons) and also, this pull request will fix a bug in which projects with public status pages cannot be toggled off (as unticked checkboxes are not sent with POST requests).
