### PR TITLE
Prefix directory option of phpLoc with buildPath

### DIFF
--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -43,7 +43,7 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     {
         $this->phpci     = $phpci;
         $this->build     = $build;
-        $this->directory = isset($options['directory']) ? $options['directory'] : $phpci->buildPath;
+        $this->directory = $phpci->buildPath . (empty($options['directory']) ? '' : $options['directory']);
     }
 
     /**


### PR DESCRIPTION
The directory option of the phpLoc plugin should be prepended with phpci buildPath, otherwise it's invalid unless user enters an absolute path. But that's not possible ofc as the path changes with each build.
