### PR TITLE
Unification configuration in PHPLoc and couting skipped test in PHPUnit plugin

### DIFF
--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -43,7 +43,7 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     {
         $this->phpci     = $phpci;
         $this->build     = $build;
-        $this->directory = $phpci->buildPath . (isset($options['directory']) ? $options['directory'] : "");
+        $this->directory = isset($options['directory']) ? $options['directory'] : "";
     }
 
     /**
@@ -68,7 +68,7 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
             return false;
         }
 
-        $success = $this->phpci->executeCommand($phploc . ' %s "%s"', $ignore, $this->directory);
+        $success = $this->phpci->executeCommand($phploc . ' %s %s', $ignore, $this->getTargetDirectory());
         $output = $this->phpci->getLastOutput();
 
         if (preg_match_all('/\((LOC|CLOC|NCLOC|LLOC)\)\s+([0-9]+)/', $output, $matches)) {
@@ -82,4 +82,15 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
         return $success;
     }
+
+    protected function getTargetDirectory()
+    {
+        $path = $this->phpci->buildPath . $this->directory;
+        if (!empty($this->directory) && $this->directory{0} == '/') {
+            $path = $this->directory;
+            return $path;
+        }
+        return $path;
+    }
+
 }

--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -43,7 +43,7 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     {
         $this->phpci     = $phpci;
         $this->build     = $build;
-        $this->directory = isset($options['directory']) ? $options['directory'] : $phpci->buildPath;
+        $this->directory = $phpci->buildPath . (isset($options['directory']) ? $options['directory'] : "");
     }
 
     /**

--- a/PHPCI/Plugin/Util/TapParser.php
+++ b/PHPCI/Plugin/Util/TapParser.php
@@ -6,6 +6,7 @@ class TapParser
 {
     const TEST_COUNTS_PATTERN = '/([0-9]+)\.\.([0-9]+)/';
     const TEST_LINE_PATTERN = '/(ok|not ok)\s+[0-9]+\s+\-\s+([^\n]+)::([^\n]+)/';
+	const TEST_SKIP_LINE_PATTERN = '/(ok|not ok)\s+[0-9]+\s+\-\s+\#\s+SKIP([^\n]+)/i';
     const TEST_MESSAGE_PATTERN = '/message\:\s+\'([^\']+)\'/';
     const TEST_COVERAGE_PATTERN = '/Generating code coverage report/';
 
@@ -92,6 +93,20 @@ class TapParser
                 );
 
                 $rtn[] = $item;
+			} elseif (preg_match(self::TEST_SKIP_LINE_PATTERN, $line, $matches)) {
+				$ok = ($matches[1] == 'ok' ? true : false);
+
+				if (!$ok) {
+					$this->failures++;
+				}
+
+				$item = array(
+					'pass' => $ok,
+					'suite' => $matches[2],
+					'test' => $matches[2],
+				);
+
+				$rtn[] = $item;
             } elseif (preg_match(self::TEST_MESSAGE_PATTERN, $line, $matches)) {
                 $rtn[count($rtn) - 1]['message'] = $matches[1];
             }


### PR DESCRIPTION
I had a problem with configuration PHPLoc, because I wanted to couting only files in one dictionary. So, I copy method getTargetPath from PHPMassDetector and prepared a new method getTargetDictionary in PHPLoc class. 

Second change was add recognition a skipped test in PHPUnit plugin.