### PR TITLE
Committer email in /webhook/git controller

### DIFF
--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -60,7 +60,7 @@ class WebhookController extends \PHPCI\Controller
     }
 
     /**
-     * Called by POSTing to /git/webhook/<project_id>?branch=<branch>&commit=<commit>
+     * Called by POSTing to /webhook/git/<project_id>?branch=<branch>&commit=<commit>&committer_email=<email>
      *
      * @param string $project
      */
@@ -68,6 +68,7 @@ class WebhookController extends \PHPCI\Controller
     {
         $branch = $this->getParam('branch');
         $commit = $this->getParam('commit');
+        $committerEmail = $this->getParam('committer_email');
 
         try {
             if (empty($branch)) {
@@ -78,7 +79,11 @@ class WebhookController extends \PHPCI\Controller
                 $commit = null;
             }
 
-            $this->createBuild($project, $commit, $branch, null, null);
+            if (empty($committerEmail)) {
+                $committerEmail = null;
+            }
+
+            $this->createBuild($project, $commit, $branch, $committerEmail, null);
 
         } catch (\Exception $ex) {
             header('HTTP/1.1 400 Bad Request');


### PR DESCRIPTION
This commit adds the ability of committer email set. 

And `post-receive` git hook will be like this:

``` bash
#!/bin/sh

PROJECT_ID=1
PHPCI_URL="http://my.server.com/PHPCI/"

trigger_hook() {
        BRANCH=$(git rev-parse --symbolic --abbrev-ref $3)
        COMMITTER_EMAIL=$(git --no-pager show -s --format='%ae' $2)

        echo "Sending webhook"
        curl "$PHPCI_URL/webhook/git/$PROJECT_ID?branch=$BRANCH&commit=$2&committer_email=$COMMITTER_EMAIL"
}

if [ -n "$1" -a -n "$2" -a -n "$3" ]; then
        PAGER= trigger_hook $1 $2 $3
else
        while read oldrev newrev refname
        do
                trigger_hook $oldrev $newrev $refname
        done
fi
```
