### PR TITLE
Add build path to phploc directory

### DIFF
--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -43,7 +43,9 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     {
         $this->phpci     = $phpci;
         $this->build     = $build;
-        $this->directory = isset($options['directory']) ? $options['directory'] : $phpci->buildPath;
+        $this->directory = isset($options['directory']) ?
+            $phpci->buildPath . '/' . $options['directory'] :
+            $phpci->buildPath;
     }
 
     /**


### PR DESCRIPTION
I was getting told "No files found to scan" from the phploc plugin. Tried with a leading slash:

```
RUNNING PLUGIN: php_loc
Executing: /var/www/phpci/vendor/bin/phploc  --exclude /lib/vendor --exclude /lib/tests "/lib/src"
phploc 2.0.6 by Sebastian Bergmann.

No files found to scan
```

And without:

```
RUNNING PLUGIN: php_loc
Executing: /var/www/phpci/vendor/bin/phploc  --exclude /lib/vendor --exclude /lib/tests "lib/src"
phploc 2.0.6 by Sebastian Bergmann.

No files found to scan
```

This change has fixed it so I now get phploc output and a working LoC chart.  That said, the command line now has a double slash at the start, so I guess there's something else going on as well...

```
RUNNING PLUGIN: php_loc
Executing: /var/www/phpci/vendor/bin/phploc  --exclude /lib/vendor --exclude /lib/tests "//lib/src"
phploc 2.0.6 by Sebastian Bergmann.

Directories                                          8
Files                                               17
...
```

Test output:

```
chandisi@cam-ci:~/PHPCI$ phpunit
PHPUnit 4.1.3 by Sebastian Bergmann.

Configuration read from /home/chandisi/PHPCI/phpunit.xml

................................................................. 65 / 74 ( 87%)
.........

Time: 1.52 seconds, Memory: 12.25Mb

OK (74 tests, 137 assertions)
```
