### PR TITLE
[WIP] Add support for PHP Metrics

### DIFF
--- a/PHPCI/Command/InstallCommand.php
+++ b/PHPCI/Command/InstallCommand.php
@@ -15,6 +15,7 @@ use PDO;
 use b8\Config;
 use b8\Database;
 use b8\Store\Factory;
+use PHPCI\Service\UserService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -382,7 +382,7 @@ class ProjectController extends \PHPCI\Controller
 
             if (in_array($type, $validators) && !preg_match($validators[$type]['regex'], $val)) {
                 throw new \Exception($validators[$type]['message']);
-            } elseif ($type == 'local' && !is_dir($val)) {
+            } elseif ($type == 'local' && !is_dir($values['reference'])) {
                 throw new \Exception('The path you specified does not exist.');
             }
 

--- a/PHPCI/Plugin/PhpMetrics.php
+++ b/PHPCI/Plugin/PhpMetrics.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * PHPCI - Continuous Integration for PHP
+ *
+ * @copyright    Copyright 2014, Block 8 Limited.
+ * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ * @link         https://www.phptesting.org/
+ */
+
+namespace PHPCI\Plugin;
+
+use PHPCI;
+use PHPCI\Builder;
+use PHPCI\Model\Build;
+
+/**
+* PhpMetrics  Plugin - Allows PHPMetrics integration.
+* @author       Jean-François Lépine <lepinejeanfrancois@yahoo.fr>
+* @package      PHPCI
+* @subpackage   Plugins
+*/
+class PhpMetrics implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
+{
+    /**
+     * @var \PHPCI\Builder
+     */
+    protected $phpci;
+
+    /**
+     * @var \PHPCI\Model\Build
+     */
+    protected $build;
+
+    /**
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * @var array
+     */
+    protected $extensions;
+
+    /**
+     * @var string
+     */
+    protected $failure;
+
+    /**
+     * @var array
+     */
+    protected $exclude;
+
+    /**
+     * @var string
+     */
+    protected $configFile;
+
+    /**
+     * @inheritdoc
+     */
+    public static function canExecute($stage, Builder $builder, Build $build)
+    {
+        if ($stage == 'test') {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct(Builder $phpci, Build $build, array $options = array())
+    {
+        $this->phpci = $phpci;
+        $this->build = $build;
+
+        $this->path = rtrim($this->phpci->buildPath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+
+        if (isset($options['zero_config']) && $options['zero_config']) {
+            $this->allowed_warnings = -1;
+        }
+
+        if (!empty($options['path'])) {
+            $this->path = $this->path.$options['path'];
+        }
+
+        if (array_key_exists('allowed_warnings', $options)) {
+            $this->allowed_warnings = (int)$options['allowed_warnings'];
+        }
+
+        foreach (array('exclude', 'extensions', 'failure') as $key) {
+            $this->overrideSetting($options, $key);
+        }
+
+        if (empty($options['config']) && empty($options['directory'])) {
+            $this->configFile = file_exists($this->phpci->buildPath . '.phpmetrics.yml')
+                    ? $this->phpci->buildPath . '.phpmetrics.yml'
+                    : null;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        $bin = $this->phpci->findBinary('phpmetrics');
+        if (!$bin) {
+            $this->phpci->logFailure('Could not find PhpMetrics.');
+            return false;
+        }
+        $success = $this->executePhpMetrics($bin);
+
+        if(!$success) {
+            $this->phpci->log($this->phpci->getLastOutput());
+            throw new \Exception('Could not run PhpMetrics.');
+        }
+
+        $data = $this->processReport(trim($this->phpci->getLastOutput()));
+        $this->build->storeMeta('phpmetrics', $data);
+
+        return $success;
+    }
+
+    /**
+     * Override setting
+     *
+     * @param $options
+     * @param $key
+     */
+    protected function overrideSetting($options, $key)
+    {
+        if (isset($options[$key]) && is_array($options[$key])) {
+            $this->{$key} = $options[$key];
+        }
+    }
+
+    /**
+     * Processes report
+     *
+     * @param $xmlString
+     * @return \SimpleXMLElement
+     * @throws \Exception
+     */
+    protected function processReport($xmlString)
+    {
+        $project = simplexml_load_string($xmlString);
+
+        if ($project === false) {
+            $this->phpci->log($xmlString);
+            throw new \Exception('Could not process PhpMetrics report XML.');
+        }
+
+        $array = array();
+        foreach($project->attributes() as $key => $value) {
+            $array[$keyadd] = (string) $value;
+        }
+        return $array;
+    }
+
+
+    /**
+     * Execute PhpMetrics
+     *
+     * @param $bin
+     * @return bool
+     */
+    protected function executePhpMetrics($bin)
+    {
+
+        if(count($this->exclude, COUNT_NORMAL)) {
+            $args[] = sprintf('--excluded-dirs=%s', implode('|', $this->exclude));
+        }
+
+        if(count($this->extensions, COUNT_NORMAL)) {
+            $args[] = sprintf('--extensions=%s', implode('|', $this->extensions));
+        }
+
+        if(!is_null($this->failure)) {
+            $args[] = sprintf('--failure-condition=%s', $this->failure);
+        }
+
+        if(!is_null($this->configFile)) {
+            $args[] = sprintf('--config=%s', $this->configFile);
+        }
+
+        $args[] = '--report-xml=php://stdout';
+        $args[] = '--quiet';
+
+        // Disable exec output logging, as we don't want the XML report in the log:
+        $this->phpci->logExecOutput(false);
+
+        // Run PhpMetrics:
+        $cmd = sprintf('%1$s %2$s %3$s', $bin, implode(' ', $args), $this->path);
+        var_dump($cmd);
+        $success = $this->phpci->executeCommand($cmd);
+
+        // Re-enable exec output logging:
+        $this->phpci->logExecOutput(true);
+        return $success;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "atoum/atoum": "Atoum",
         "jakub-onderka/php-parallel-lint": "Parallel Linting Tool",
         "behat/behat": "Behat BDD Testing",
-        "hipchat/hipchat-php": "Hipchat integration"
+        "hipchat/hipchat-php": "Hipchat integration",
+        "halleck45/phpmetrics": "PhpMetrics integration"
     }
 }

--- a/public/assets/js/build-plugins/phpmetrics.js
+++ b/public/assets/js/build-plugins/phpmetrics.js
@@ -1,7 +1,7 @@
 var phpmetricsPlugin = PHPCI.UiPlugin.extend({
     id: 'build-lines-chart',
     css: 'col-lg-6 col-md-6 col-sm-12 col-xs-12',
-    title: 'PhpMetrics',
+    title: 'PhpMetrics Trend',
     lastData: null,
     displayOnUpdate: false,
     rendered: false,
@@ -73,3 +73,43 @@ var phpmetricsPlugin = PHPCI.UiPlugin.extend({
 });
 
 PHPCI.registerPlugin(new phpmetricsPlugin());
+
+
+
+// PhpMetrics Bubbles
+// --------------
+// WIP :
+//
+//var phpmetricsPlugin = PHPCI.UiPlugin.extend({
+//    id: 'build-log',
+//    css: 'col-lg-6 col-md-6 col-sm-12 col-xs-12',
+//    title: 'Maintenability chart',
+//    lastData: null,
+//    displayOnUpdate: false,
+//    rendered: false,
+//
+//    register: function() {
+//        var self = this;
+//        var query = PHPCI.registerQuery('phpmetrics-bubbles', -1, {num_builds: 10, key: 'phpmetrics-bubbles'})
+//
+//        $(window).on('phpmetrics-bubbles', function(data) {
+//            self.onUpdate(data);
+//        });
+//
+//        $(window).on('build-updated', function(data) {
+//            if (data.queryData.status > 1 && !self.rendered) {
+//                query();
+//            }
+//        });
+//    },
+//
+//    render: function() {
+//        return $('<div id="phpmetrics-bubbles"><embed type="image/svg+xml" src="/build/phpmetrics/chart-bubbles.svg" style="width:100%; height:100%" /></div>');
+//    },
+//
+//    onUpdate: function(e) {
+//    }
+//});
+//
+//PHPCI.registerPlugin(new phpmetricsPlugin());
+//

--- a/public/assets/js/build-plugins/phpmetrics.js
+++ b/public/assets/js/build-plugins/phpmetrics.js
@@ -1,0 +1,75 @@
+var phpmetricsPlugin = PHPCI.UiPlugin.extend({
+    id: 'build-lines-chart',
+    css: 'col-lg-6 col-md-6 col-sm-12 col-xs-12',
+    title: 'PhpMetrics',
+    lastData: null,
+    displayOnUpdate: false,
+    rendered: false,
+
+    register: function() {
+        var self = this;
+        var query = PHPCI.registerQuery('phpmetrics-lines', -1, {num_builds: 10, key: 'phpmetrics'})
+
+        $(window).on('phpmetrics-lines', function(data) {
+            self.onUpdate(data);
+        });
+
+        $(window).on('build-updated', function(data) {
+            if (data.queryData.status > 1 && !self.rendered) {
+                query();
+            }
+        });
+
+        google.load("visualization", "1", {packages:["corechart"]});
+    },
+
+    render: function() {
+        return $('<div id="phpmetrics-lines"></div>').text('This chart will display once the build has completed.');
+    },
+
+    onUpdate: function(e) {
+        this.lastData = e.queryData;
+        this.displayChart();
+    },
+
+    displayChart: function() {
+        var builds = this.lastData;
+
+        if (!builds || !builds.length) {
+            return;
+        }
+
+        this.rendered = true;
+
+        $('#phpmetrics-lines').empty().animate({height: '275px'});
+
+        var titles = ['ID', 'Maintenability', 'LCOM', 'Difficulty', 'Bugs', 'Intelligent content'];
+        var data = [titles];
+        console.log(builds);
+        for (var i in builds) {
+            data.push(
+                [
+                    '#' + builds[i].build_id
+                    , parseInt(builds[i].meta_value.maintenabilityIndex)
+                    , parseInt(builds[i].meta_value.lcom)
+                    , parseInt(builds[i].meta_value.difficulty)
+                    , parseInt(builds[i].meta_value.bugs)
+                    , parseFloat(builds[i].meta_value.intelligentContent)
+                ]
+            );
+        }
+
+        var data = google.visualization.arrayToDataTable(data);
+        var options = {
+            hAxis: {title: 'Builds'},
+            vAxis: {title: 'Lines'},
+            backgroundColor: { fill: 'transparent' },
+            height: 275
+        };
+
+        var chart = new google.visualization.LineChart(document.getElementById('phpmetrics-lines'));
+        chart.draw(data, options);
+    }
+});
+
+PHPCI.registerPlugin(new phpmetricsPlugin());


### PR DESCRIPTION
Hi,

This PR adds support of [PhpMetrics](http://www.phpmetrics.org) (cf.  #521)

+ bubbles chart
+ metrics trends (maintenability, LCOM, number of bugs...)

**I need some help to finalize this PR**. I would like to [integrate](https://github.com/Block8/PHPCI/pull/558/files#diff-b7abfbacc8eb6548391e4f2819faf99cR107) some image/html file in the build (as does [PDepend](https://github.com/Block8/PHPCI/blob/master/PHPCI/Plugin/Pdepend.php#L108) ), but these assets are not accessible from public. Is there a tool to expose assets in build ?