### PR TITLE
Adding commit message and committer e-mail to Git webhook

### DIFF
--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -77,30 +77,40 @@ class WebhookController extends \PHPCI\Controller
      *
      * @param string $project
      */
-    public function git($project)
-    {
-        $branch = $this->getParam('branch');
-        $commit = $this->getParam('commit');
+	public function git($project)
+	{
+		$branch = $this->getParam('branch');
+		$commit = $this->getParam('commit');
+		$commitMessage = $this->getParam('message');
+		$committer = $this->getParam('committer');
 
-        try {
-            if (empty($branch)) {
-                $branch = 'master';
-            }
+		try {
+			if (empty($branch)) {
+				$branch = 'master';
+			}
 
-            if (empty($commit)) {
-                $commit = null;
-            }
+			if (empty($commit)) {
+				$commit = null;
+			}
 
-            $this->createBuild($project, $commit, $branch, null, null);
+			if (empty($commitMessage)) {
+				$commitMessage = null;
+			}
 
-        } catch (\Exception $ex) {
-            header('HTTP/1.1 400 Bad Request');
-            header('Ex: ' . $ex->getMessage());
-            die('FAIL');
-        }
+			if (empty($committer)) {
+				$committer = null;
+			}
 
-        die('OK');
-    }
+			$this->createBuild($project, $commit, $branch, $committer, $commitMessage);
+
+		} catch (\Exception $ex) {
+			header('HTTP/1.1 400 Bad Request');
+			header('Ex: ' . $ex->getMessage());
+			die('FAIL');
+		}
+
+		die('OK');
+	}
 
     /**
      * Called by Github Webhooks:


### PR DESCRIPTION
In Git Webhook is missing Committer e-mail and commit message. I don't understant why, other hooks has commit message. This should fix it. 

With this PR, I can hav phpci on my local machine and add Git Hook like that: [post-commit](https://gist.github.com/PetrHudik/d4fd7610c81a5eb5f673).
