### PR TITLE
Gitlab CI merge request service

### DIFF
--- a/PHPCI/Controller/BuildStatusController.php
+++ b/PHPCI/Controller/BuildStatusController.php
@@ -149,7 +149,7 @@ class BuildStatusController extends \PHPCI\Controller
 
         if (!$build) {
             $this->response->setResponseCode(404);
-        } elseif (!$build->getProject()->getAllowPublicStatus()) {
+        } elseif (!$build->getProject()->allowAccess($this->request->getParam('auth_token'))) {
             $this->response->setResponseCode(401);
         } elseif ($build) {
             $this->response->disableLayout();

--- a/PHPCI/Controller/BuildStatusController.php
+++ b/PHPCI/Controller/BuildStatusController.php
@@ -31,6 +31,9 @@ class BuildStatusController extends \PHPCI\Controller
     protected $projectStore;
     protected $buildStore;
 
+    /**
+     * Initialize the service required from this class.
+     */
     public function init()
     {
         $this->response->disableLayout();
@@ -39,8 +42,11 @@ class BuildStatusController extends \PHPCI\Controller
     }
 
     /**
-     * Returns status of the last build
-     * @param $projectId
+     * Returns status of the last build.
+     *
+     * @param int $projectId
+     *   The project ID
+     *
      * @return string
      */
     protected function getStatus($projectId)
@@ -69,8 +75,11 @@ class BuildStatusController extends \PHPCI\Controller
     }
 
     /**
-    * Returns the appropriate build status image for a given project.
-    */
+     * Returns the appropriate build status image for a given project.
+     *
+     * @param int $projectId
+     *   The project ID
+     */
     public function image($projectId)
     {
         $status = $this->getStatus($projectId);
@@ -79,8 +88,11 @@ class BuildStatusController extends \PHPCI\Controller
     }
 
     /**
-    * Returns the appropriate build status image in SVG format for a given project.
-    */
+     * Returns the appropriate build status image in SVG format for a given project.
+     *
+     * @param int $projectId
+     *   The project ID
+     */
     public function svg($projectId)
     {
         $status = $this->getStatus($projectId);
@@ -88,6 +100,12 @@ class BuildStatusController extends \PHPCI\Controller
         die(file_get_contents(APPLICATION_PATH . 'public/assets/img/build-' . $status . '.svg'));
     }
 
+    /**
+     * View the page for the specified project.
+     *
+     * @param int $projectId
+     *   The project ID
+     */
     public function view($projectId)
     {
         $project = $this->projectStore->getById($projectId);
@@ -163,7 +181,13 @@ class BuildStatusController extends \PHPCI\Controller
     }
 
     /**
-     * Render latest builds for project as HTML table.
+     * Extract latest builds (maximum 10) for the specified project.
+     *
+     * @param int $projectId
+     *   The project ID
+     *
+     * @param array
+     *   Array with the latest build for the specified project.
      */
     protected function getLatestBuilds($projectId)
     {

--- a/PHPCI/Controller/BuildStatusController.php
+++ b/PHPCI/Controller/BuildStatusController.php
@@ -10,6 +10,7 @@
 namespace PHPCI\Controller;
 
 use b8;
+use b8\Exception\HttpException\ForbiddenException;
 use b8\Exception\HttpException\NotFoundException;
 use b8\Store;
 use PHPCI\BuildFactory;
@@ -148,9 +149,9 @@ class BuildStatusController extends \PHPCI\Controller
         $build = reset($builds['items']);
 
         if (!$build) {
-            $this->response->setResponseCode(404);
+            throw new NotFoundException('Project with id ' . $projectId . 'or commit ' . $commitId . ' not found');
         } elseif (!$build->getProject()->allowAccess($this->request->getParam('auth_token'))) {
-            $this->response->setResponseCode(401);
+            throw new ForbiddenException('You do not have permission to do that.');
         } elseif ($build) {
             $this->response->disableLayout();
             $this->response->setResponseCode(200);

--- a/PHPCI/Controller/BuildStatusController.php
+++ b/PHPCI/Controller/BuildStatusController.php
@@ -168,7 +168,7 @@ class BuildStatusController extends \PHPCI\Controller
 
         if (!$build) {
             throw new NotFoundException('Project with id ' . $projectId . 'or commit ' . $commitId . ' not found');
-        } elseif (!$build->getProject()->allowAccess($this->request->getParam('auth_token'))) {
+        } elseif (!$build->getProject()->isAccessAllowed($this->request->getParam('auth_token'))) {
             throw new ForbiddenException('You do not have permission to do that.');
         } elseif ($build) {
             $this->response->disableLayout();

--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -410,13 +410,13 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-     * Validate information from project create/editing form.
+     * Create validators for project create/editing form.
      *
      * @param array $values
      *   Values to validate.
      *
-     * @return bool
-     *    Indicate if values are valid.
+     * @return callback
+     *    Validator to validate information.
      */
     protected function getReferenceValidator($values)
     {

--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -51,6 +51,9 @@ class ProjectController extends \PHPCI\Controller
      */
     protected $buildService;
 
+    /**
+     * Initialize services required from this class.
+     */
     public function init()
     {
         $this->buildStore = Store\Factory::getStore('Build');
@@ -60,8 +63,14 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * View a specific project.
-    */
+     * View a specific project.
+     *
+     * @param int $projectId
+     *   The project id to show.
+     *
+     * @return string
+     *   The rendered project page markup.
+     */
     public function view($projectId)
     {
         $project = $this->projectStore->getById($projectId);
@@ -91,8 +100,13 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * Create a new pending build for a project.
-    */
+     * Create a new pending build for a project.
+     *
+     * After create a new build in the queue redirect the user to the build page.
+     *
+     * @param int $projectId
+     *   The project id to build.
+     */
     public function build($projectId)
     {
         /* @var \PHPCI\Model\Project $project */
@@ -109,8 +123,13 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * Delete a project.
-    */
+     * Delete a project.
+     *
+     * After deleting the project redirect the user to home page.
+     *
+     * @param int $projectId
+     *   The project id to delete
+     */
     public function delete($projectId)
     {
         if (!$_SESSION['user']->getIsAdmin()) {
@@ -125,8 +144,14 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * AJAX get latest builds.
-    */
+     * AJAX get latest builds.
+     *
+     * @param int $projectId
+     *   The project id to show.
+     *
+     * @return string
+     *   The rendered table with latest build.
+     */
     public function builds($projectId)
     {
         $builds = $this->getLatestBuildsHtml($projectId);
@@ -134,8 +159,17 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * Render latest builds for project as HTML table.
-    */
+     * Render latest builds for project as HTML table.
+     *
+     * @param int $projectId
+     *   The project id to show.
+     *
+     * @param int $start
+     *   The start position for the build.
+     *
+     * @return string
+     *   Rendered html table with the latest builds for the specified project.
+     */
     protected function getLatestBuildsHtml($projectId, $start = 0)
     {
         $criteria = array('project_id' => $projectId);
@@ -153,8 +187,10 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * Add a new project. Handles both the form, and processing.
-    */
+     * Add a new project. Handles both the form, and processing.
+     *
+     * @return string
+     */
     public function add()
     {
         $this->config->set('page_title', 'Add Project');
@@ -206,8 +242,13 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * Edit a project. Handles both the form and processing.
-    */
+     * Edit a project. Handles both the form and processing.
+     *
+     * @param int $projectId
+     *   The project id to edit.
+     *
+     * @return string
+     */
     public function edit($projectId)
     {
         if (!$_SESSION['user']->getIsAdmin()) {
@@ -269,8 +310,17 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * Create add / edit project form.
-    */
+     * Create add / edit project form.
+     *
+     * @param array $values
+     *   Values to use to prepopulate form elements.
+     *
+     * @param string $type
+     *   Type of operation to perform, can be 'add' or 'edit'.
+     *
+     * @return b8\Form
+     *   Form to display to edit a new project.
+     */
     protected function projectForm($values, $type = 'add')
     {
         $form = new Form();
@@ -351,14 +401,23 @@ class ProjectController extends \PHPCI\Controller
     }
 
     /**
-    * Get an array of repositories from Github's API.
-    */
+     * Get an array of repositories from Github's API.
+     */
     protected function githubRepositories()
     {
         $github = new Github();
         die(json_encode($github->getRepositories()));
     }
 
+    /**
+     * Validate information from project create/editing form.
+     *
+     * @param array $values
+     *   Values to validate.
+     *
+     * @return bool
+     *    Indicate if values are valid.
+     */
     protected function getReferenceValidator($values)
     {
         return function ($val) use ($values) {

--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -172,6 +172,7 @@ class ProjectController extends \PHPCI\Controller
             $values['key']    = $key['private_key'];
             $values['pubkey'] = $key['public_key'];
             $pub = $key['public_key'];
+            $values['auth_token'] = $this->genrateAuthToken();
         }
 
         $form = $this->projectForm($values);
@@ -195,6 +196,7 @@ class ProjectController extends \PHPCI\Controller
                 'build_config' => $this->getParam('build_config', null),
                 'allow_public_status' => $this->getParam('allow_public_status', 0),
                 'branch' => $this->getParam('branch', null),
+                'auth_token' => $this->getParam('auth_token', null),
             );
 
             $project = $this->projectService->createProject($title, $type, $reference, $options);
@@ -257,6 +259,7 @@ class ProjectController extends \PHPCI\Controller
             'build_config' => $this->getParam('build_config', null),
             'allow_public_status' => $this->getParam('allow_public_status', 0),
             'branch' => $this->getParam('branch', null),
+            'auth_token' => $this->getParam('auth_token', null),
         );
 
         $project = $this->projectService->updateProject($project, $title, $type, $reference, $options);
@@ -333,6 +336,10 @@ class ProjectController extends \PHPCI\Controller
         $field->setValue(0);
         $form->addField($field);
 
+        $field = Form\Element\Text::create('auth_token', 'Authentication token', false);
+        $field->setClass('form-control')->setContainerClass('form-group');
+        $form->addField($field);
+
         $field = new Form\Element\Submit();
         $field->setValue('Save Project');
         $field->setContainerClass('form-group');
@@ -388,5 +395,17 @@ class ProjectController extends \PHPCI\Controller
 
             return true;
         };
+    }
+
+    /**
+     * Generate an unpredictible string to use as authentication token.
+     *
+     * @return string
+     *   A random string.
+     */
+    protected function genrateAuthToken()
+    {
+        $ret = bin2hex(openssl_random_pseudo_bytes(32));
+        return $ret;
     }
 }

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -73,7 +73,7 @@ class WebhookController extends \PHPCI\Controller
     }
 
     /**
-     * Called by POSTing to /git/webhook/<project_id>?branch=<branch>&commit=<commit>
+     * Called by POSTing to /webhook/git/<project_id>?branch=<branch>&commit=<commit>
      *
      * @param string $project
      */

--- a/PHPCI/Migrations/20140823201239_project_auth_token.php
+++ b/PHPCI/Migrations/20140823201239_project_auth_token.php
@@ -1,0 +1,27 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ProjectAuthToken extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $project = $this->table('project');
+        $project->addColumn('auth_token', 'string', array(
+            'after' => 'branch',
+            'limit' => 250
+        ))->save();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $project = $this->table('project');
+        $project->removeColumn('auth_token')->save();
+    }
+}

--- a/PHPCI/Model/Base/ProjectBase.php
+++ b/PHPCI/Model/Base/ProjectBase.php
@@ -37,6 +37,7 @@ class ProjectBase extends Model
         'title' => null,
         'reference' => null,
         'branch' => null,
+        'auth_token' => null,
         'ssh_private_key' => null,
         'ssh_public_key' => null,
         'type' => null,
@@ -55,6 +56,7 @@ class ProjectBase extends Model
         'title' => 'getTitle',
         'reference' => 'getReference',
         'branch' => 'getBranch',
+        'auth_token' => 'getAuthToken',
         'ssh_private_key' => 'getSshPrivateKey',
         'ssh_public_key' => 'getSshPublicKey',
         'type' => 'getType',
@@ -75,6 +77,7 @@ class ProjectBase extends Model
         'title' => 'setTitle',
         'reference' => 'setReference',
         'branch' => 'setBranch',
+        'auth_token' => 'setAuthToken',
         'ssh_private_key' => 'setSshPrivateKey',
         'ssh_public_key' => 'setSshPublicKey',
         'type' => 'setType',
@@ -108,6 +111,11 @@ class ProjectBase extends Model
             'default' => null,
         ),
         'branch' => array(
+            'type' => 'varchar',
+            'length' => 250,
+            'default' => null,
+        ),
+        'auth_token' => array(
             'type' => 'varchar',
             'length' => 250,
             'default' => null,
@@ -208,6 +216,18 @@ class ProjectBase extends Model
     public function getBranch()
     {
         $rtn    = $this->data['branch'];
+
+        return $rtn;
+    }
+
+    /**
+     * Get the value of Auth token.
+     *
+     * @return string|null
+     */
+    public function getAuthToken()
+    {
+        $rtn    = $this->data['auth_token'];
 
         return $rtn;
     }
@@ -374,6 +394,24 @@ class ProjectBase extends Model
         $this->data['branch'] = $value;
 
         $this->_setModified('branch');
+    }
+
+    /**
+     * Set the value of authentication token.
+     *
+     * @param string|null $value
+     */
+    public function setAuthToken($value)
+    {
+        $this->_validateString('AuthToken', $value);
+
+        if ($this->data['auth_token'] === $value) {
+            return;
+        }
+
+        $this->data['auth_token'] = $value;
+
+        $this->_setModified('auth_token');
     }
 
     /**

--- a/PHPCI/Model/Build/GitlabBuild.php
+++ b/PHPCI/Model/Build/GitlabBuild.php
@@ -65,20 +65,20 @@ class GitlabBuild extends RemoteGitBuild
     public function getGilabStatus()
     {
         switch ($this->getStatus()) {
-          case self::STATUS_NEW:
-            return 'pending';
-            break;
-          case self::STATUS_RUNNING:
-            return 'running';
-            break;
-          case self::STATUS_SUCCESS:
-            return 'success';
-            break;
-          case self::STATUS_FAILED:
-            return 'failed';
-            break;
-          default:
-            throw new \Exception('Status not valid');
+            case self::STATUS_NEW:
+                return 'pending';
+                break;
+            case self::STATUS_RUNNING:
+                return 'running';
+                break;
+            case self::STATUS_SUCCESS:
+                return 'success';
+                break;
+            case self::STATUS_FAILED:
+                return 'failed';
+                break;
+            default:
+                throw new \Exception('Status not valid');
         }
     }
 

--- a/PHPCI/Model/Build/GitlabBuild.php
+++ b/PHPCI/Model/Build/GitlabBuild.php
@@ -9,7 +9,6 @@
 
 namespace PHPCI\Model\Build;
 
-use PHPCI\Model\Build;
 use PHPCI\Model\Build\RemoteGitBuild;
 
 /**
@@ -66,16 +65,16 @@ class GitlabBuild extends RemoteGitBuild
     public function getGilabStatus()
     {
         switch ($this->getStatus()) {
-          case Build::STATUS_NEW:
+          case self::STATUS_NEW:
             return 'pending';
             break;
-          case Build::STATUS_RUNNING:
+          case self::STATUS_RUNNING:
             return 'running';
             break;
-          case Build::STATUS_SUCCESS:
+          case self::STATUS_SUCCESS:
             return 'success';
             break;
-          case Build::STATUS_FAILED:
+          case self::STATUS_FAILED:
             return 'failed';
             break;
           default:

--- a/PHPCI/Model/Build/GitlabBuild.php
+++ b/PHPCI/Model/Build/GitlabBuild.php
@@ -93,8 +93,6 @@ class GitlabBuild extends RemoteGitBuild
      *   Build data with:
      *     - branch: branch name
      *     - commit: commit hash
-     *     - message: commit message
-     *     - committer: committer mail
      *     - id: build id
      *     - project: project name configured on PHPCI
      *     - status: build status in string format
@@ -111,11 +109,13 @@ class GitlabBuild extends RemoteGitBuild
           // Git related informations.
           'branch' => $this->getBranch(),
           'commit' => $this->getCommitId(),
+
           // Build related informations.
           'id' => $this->getId(),
           'status' => $this->getGilabStatus(),
           'log' => $this->getLog(),
 
+          // Build timing.
           'created' => $this->getCreated()->format(\DateTime::ISO8601),
           'started' => $this->getStarted()->format(\DateTime::ISO8601),
           'finished' => $this->getFinished()->format(\DateTime::ISO8601),

--- a/PHPCI/Model/Build/GitlabBuild.php
+++ b/PHPCI/Model/Build/GitlabBuild.php
@@ -9,6 +9,7 @@
 
 namespace PHPCI\Model\Build;
 
+use PHPCI\Model\Build;
 use PHPCI\Model\Build\RemoteGitBuild;
 
 /**
@@ -49,6 +50,78 @@ class GitlabBuild extends RemoteGitBuild
             $this->getProject()->getReference(),
             $this->getBranch()
         );
+    }
+
+    /**
+     * Convert status code to string format.
+     *
+     * @param int $status
+     *   Build status code.
+     *
+     * @return string
+     *   Status code, can be 'pending', 'running', 'success' or 'failed'.
+     *
+     * @throw Exception
+     */
+    public function getGilabStatus()
+    {
+        switch ($this->getStatus()) {
+          case Build::STATUS_NEW:
+            return 'pending';
+            break;
+          case Build::STATUS_RUNNING:
+            return 'running';
+            break;
+          case Build::STATUS_SUCCESS:
+            return 'success';
+            break;
+          case Build::STATUS_FAILED:
+            return 'failed';
+            break;
+          default:
+            throw new \Exception('Status not valid');
+        }
+    }
+
+    /**
+     * Convert build class to object that can be converted to JSON string.
+     *
+     * @param Build $build
+     *   Build to be converted
+     *
+     * @return array
+     *   Build data with:
+     *     - branch: branch name
+     *     - commit: commit hash
+     *     - message: commit message
+     *     - committer: committer mail
+     *     - id: build id
+     *     - project: project name configured on PHPCI
+     *     - status: build status in string format
+     *     - log: the build log result
+     *     - created: build creation time in ISO8601 format
+     *     - started: build starting time in ISO8601 format
+     *     - finished: build finishing time in ISO8601 format
+     *
+     * @throw Exception
+     */
+    public function convertJSON()
+    {
+        $result = array(
+          // Git related informations.
+          'branch' => $this->getBranch(),
+          'commit' => $this->getCommitId(),
+          // Build related informations.
+          'id' => $this->getId(),
+          'status' => $this->getGilabStatus(),
+          'log' => $this->getLog(),
+
+          'created' => $this->getCreated()->format(\DateTime::ISO8601),
+          'started' => $this->getStarted()->format(\DateTime::ISO8601),
+          'finished' => $this->getFinished()->format(\DateTime::ISO8601),
+        );
+
+        return json_encode($result);
     }
 
     /**

--- a/PHPCI/Model/Project.php
+++ b/PHPCI/Model/Project.php
@@ -72,6 +72,12 @@ class Project extends ProjectBase
         parent::setAccessInformation($value);
     }
 
+    /**
+     * Getter for project access information property.
+     *
+     * @param string $key
+     *   Key into access information to find.
+     */
     public function getAccessInformation($key = null)
     {
         $info = $this->data['access_information'];

--- a/PHPCI/Model/Project.php
+++ b/PHPCI/Model/Project.php
@@ -22,6 +22,18 @@ use b8\Store;
 */
 class Project extends ProjectBase
 {
+    /**
+     * Get latest build for the project.
+     *
+     * @param string $branch
+     *   The branch used in the build to search.
+     *
+     * @param int $status
+     *   The result status for the build to search.
+     *
+     * @return PHPCI\Model\Build|null
+     *   Build or null if no build match specified criteria.
+     */
     public function getLatestBuild($branch = 'master', $status = null)
     {
         $criteria       = array('branch' => $branch, 'project_id' => $this->getId());
@@ -44,6 +56,13 @@ class Project extends ProjectBase
         return null;
     }
 
+    /**
+     * Setter for project access information property.
+     *
+     * @param mixed $value
+     *   Information to be stored, if array the value will be converted as json
+     *   string to be stored into DB.
+     */
     public function setAccessInformation($value)
     {
         if (is_array($value)) {
@@ -89,7 +108,19 @@ class Project extends ProjectBase
         }
     }
 
-    public function allowAccess($auth_token = null)
+    /**
+     * Check is project can be accessible
+     *
+     * The project access is validated using public visibility or -if set- by
+     * authorization token.
+     *
+     * @param string $auth_token
+     *   The autorization token used to validate access.
+     *
+     * @return bool
+     *   Indicate if the project can be accessed.
+     */
+    public function isAccessAllowed($auth_token = null)
     {
         if ($this->getAllowPublicStatus()) {
             return true;

--- a/PHPCI/Model/Project.php
+++ b/PHPCI/Model/Project.php
@@ -88,4 +88,21 @@ class Project extends ProjectBase
             return $this->data['branch'];
         }
     }
+
+    public function allowAccess($auth_token = null)
+    {
+        if ($this->getAllowPublicStatus()) {
+            return true;
+        }
+
+        if (is_null($auth_token)) {
+            return false;
+        }
+
+        if (is_null($this->getAuthToken())) {
+            return false;
+        }
+
+        return $auth_token === $this->getAuthToken();
+    }
 }

--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -12,6 +12,12 @@ namespace PHPCI\Service;
 use PHPCI\Model\Project;
 use PHPCI\Store\ProjectStore;
 
+/**
+ * Gitlab Project Service
+ *
+ * @package      PHPCI
+ * @subpackage   Core
+ */
 class ProjectService
 {
     /**

--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -80,6 +80,10 @@ class ProjectService
             $project->setBranch($options['branch']);
         }
 
+        if (array_key_exists('auth_token', $options)) {
+            $project->setAuthToken($options['auth_token']);
+        }
+
         // Allow certain project types to set access information:
         $this->processAccessInformation($project);
 

--- a/Tests/PHPCI/Model/ProjectTest.php
+++ b/Tests/PHPCI/Model/ProjectTest.php
@@ -106,4 +106,28 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($project->getAccessInformation('item3'));
         $this->assertEquals($info, $project->getAccessInformation());
     }
+
+    /**
+     * @covers PHPUnit::execute
+     */
+    public function testExecute_TestProjectAllowAccess()
+    {
+        $project = new Project();
+        $auth_token_0 = '0000000000000000000000000000000000000000000000000000000000000000';
+        $auth_token_1 = '1111111111111111111111111111111111111111111111111111111111111111';
+
+        $project->setAuthToken(null);
+        $project->setAllowPublicStatus(false);
+        $this->assertFalse($project->allowAccess());
+
+        $project->setAuthToken(null);
+        $project->setAllowPublicStatus(true);
+        $this->assertTrue($project->allowAccess());
+
+        $project->setAuthToken($auth_token_0);
+        $project->setAllowPublicStatus(false);
+        $this->assertFalse($project->allowAccess());
+        $this->assertFalse($project->allowAccess($auth_token_1));
+        $this->assertTrue($project->allowAccess($auth_token_0));
+    }
 }

--- a/Tests/PHPCI/Model/ProjectTest.php
+++ b/Tests/PHPCI/Model/ProjectTest.php
@@ -118,16 +118,16 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
 
         $project->setAuthToken(null);
         $project->setAllowPublicStatus(false);
-        $this->assertFalse($project->allowAccess());
+        $this->assertFalse($project->isAccessAllowed());
 
         $project->setAuthToken(null);
         $project->setAllowPublicStatus(true);
-        $this->assertTrue($project->allowAccess());
+        $this->assertTrue($project->isAccessAllowed());
 
         $project->setAuthToken($auth_token_0);
         $project->setAllowPublicStatus(false);
-        $this->assertFalse($project->allowAccess());
-        $this->assertFalse($project->allowAccess($auth_token_1));
-        $this->assertTrue($project->allowAccess($auth_token_0));
+        $this->assertFalse($project->isAccessAllowed());
+        $this->assertFalse($project->isAccessAllowed($auth_token_1));
+        $this->assertTrue($project->isAccessAllowed($auth_token_0));
     }
 }


### PR DESCRIPTION
This is a first implementation of exposed entrypoint to build gitlab ci service to integrate PHPCI as CI server.

Actually I have JSON conversion into Gitlab class, maybe will be better have a more generic helper to allow all type of build to be converted on JSON. Before I implemented it on controller and after moved on ```PHPCI\Model\Build``` but I'm not sure is a good place to store this conversion. Maybe a new helper class? Any suggestion?

I think is required a token to allow information reading without expose project information as public.

Test are required, please do not merge, just use this MR as support request :smile:.

Next steps:

 - [ ] define better solution to convert build to JSON
 - [x] introduce a validation token to allow non public project to be read
 - [ ] add tests
 - [x] implement phpci_ci_service similar to [gitlab_ci_service](https://github.com/gitlabhq/gitlabhq/blob/master/app%2Fmodels%2Fproject_services%2Fgitlab_ci_service.rb)