### PR TITLE
[FEATURE] Add option "allowedBranches" and variables in filename to PackageBuild plugin

### DIFF
--- a/PHPCI/Plugin/PackageBuild.php
+++ b/PHPCI/Plugin/PackageBuild.php
@@ -33,7 +33,7 @@ class PackageBuild implements \PHPCI\Plugin
         $this->directory       = isset($options['directory']) ? $options['directory'] : $path;
         $this->filename        = isset($options['filename']) ? $options['filename'] : 'build';
         $this->format          = isset($options['format']) ?  $options['format'] : 'zip';
-		$this->allowedBranches = isset($options['allowedBranches']) ?  $options['allowedBranches'] : NULL;
+        $this->allowedBranches = isset($options['allowedBranches']) ?  $options['allowedBranches'] : NULL;
     }
 
     /**
@@ -48,16 +48,16 @@ class PackageBuild implements \PHPCI\Plugin
             return false;
         }
 
-		if ($this->allowedBranches === NULL || !preg_match('/' . $this->allowedBranches . '/i', $build->getBranch())) {
-			return false;
-		}
+        if ($this->allowedBranches === NULL || !preg_match('/' . $this->allowedBranches . '/i', $build->getBranch())) {
+            return false;
+        }
 
-		$directory = $this->replaceVariables($this->directory, $build, FALSE);
-		$filename = $this->replaceVariables($this->filename, $build);
+        $directory = $this->replaceVariables($this->directory, $build, FALSE);
+        $filename = $this->replaceVariables($this->filename, $build);
 
-		if (!is_dir($directory)) {
-			mkdir($directory, 0777, TRUE);
-		}
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, TRUE);
+            }
 
         $curdir = getcwd();
         chdir($this->phpci->buildPath);
@@ -86,25 +86,25 @@ class PackageBuild implements \PHPCI\Plugin
         return $success;
     }
 
-	/**
-	 * @param string $string
-	 * @param Build $build
-	 * @param boolean $stripSpecialChars
-	 * @return mixed
-	 */
-	protected function replaceVariables($string, Build $build, $stripSpecialChars = TRUE) {
-		$branch = $build->getBranch();
-		$branch = str_replace('/', '-', $branch);
+    /**
+     * @param string $string
+     * @param Build $build
+     * @param boolean $stripSpecialChars
+     * @return mixed
+     */
+    protected function replaceVariables($string, Build $build, $stripSpecialChars = TRUE) {
+        $branch = $build->getBranch();
+        $branch = str_replace('/', '-', $branch);
 
-		$replacedString = str_replace('%build.commit%', $build->getCommitId(), $string);
-		$replacedString = str_replace('%build.id%', $build->getId(), $replacedString);
-		$replacedString = str_replace('%build.branch%', $branch, $replacedString);
-		$replacedString = str_replace('%project.title%', $build->getProject()->getTitle(), $replacedString);
-		$replacedString = str_replace('%date%', date('Y-m-d'), $replacedString);
-		$replacedString = str_replace('%time%', date('Hi'), $replacedString);
-		if ($stripSpecialChars === TRUE) {
-			$replacedString = preg_replace('/([^a-zA-Z0-9_-]+)/', '', $replacedString);
-		}
-		return $replacedString;
-	}
+        $replacedString = str_replace('%build.commit%', $build->getCommitId(), $string);
+        $replacedString = str_replace('%build.id%', $build->getId(), $replacedString);
+        $replacedString = str_replace('%build.branch%', $branch, $replacedString);
+        $replacedString = str_replace('%project.title%', $build->getProject()->getTitle(), $replacedString);
+        $replacedString = str_replace('%date%', date('Y-m-d'), $replacedString);
+        $replacedString = str_replace('%time%', date('Hi'), $replacedString);
+        if ($stripSpecialChars === TRUE) {
+            $replacedString = preg_replace('/([^a-zA-Z0-9_-]+)/', '', $replacedString);
+        }
+        return $replacedString;
+    }
 }

--- a/PHPCI/Plugin/PackageBuild.php
+++ b/PHPCI/Plugin/PackageBuild.php
@@ -27,12 +27,13 @@ class PackageBuild implements \PHPCI\Plugin
 
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $path               = $phpci->buildPath;
-        $this->build        = $build;
-        $this->phpci        = $phpci;
-        $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
-        $this->filename     = isset($options['filename']) ? $options['filename'] : 'build';
-        $this->format       = isset($options['format']) ?  $options['format'] : 'zip';
+        $path                  = $phpci->buildPath;
+        $this->build           = $build;
+        $this->phpci           = $phpci;
+        $this->directory       = isset($options['directory']) ? $options['directory'] : $path;
+        $this->filename        = isset($options['filename']) ? $options['filename'] : 'build';
+        $this->format          = isset($options['format']) ?  $options['format'] : 'zip';
+		$this->allowedBranches = isset($options['allowedBranches']) ?  $options['allowedBranches'] : NULL;
     }
 
     /**
@@ -47,13 +48,16 @@ class PackageBuild implements \PHPCI\Plugin
             return false;
         }
 
-        $filename = str_replace('%build.commit%', $build->getCommitId(), $this->filename);
-        $filename = str_replace('%build.id%', $build->getId(), $filename);
-        $filename = str_replace('%build.branch%', $build->getBranch(), $filename);
-        $filename = str_replace('%project.title%', $build->getProject()->getTitle(), $filename);
-        $filename = str_replace('%date%', date('Y-m-d'), $filename);
-        $filename = str_replace('%time%', date('Hi'), $filename);
-        $filename = preg_replace('/([^a-zA-Z0-9_-]+)/', '', $filename);
+		if ($this->allowedBranches === NULL || !preg_match('/' . $this->allowedBranches . '/i', $build->getBranch())) {
+			return false;
+		}
+
+		$directory = $this->replaceVariables($this->directory, $build, FALSE);
+		$filename = $this->replaceVariables($this->filename, $build);
+
+		if (!is_dir($directory)) {
+			mkdir($directory, 0777, TRUE);
+		}
 
         $curdir = getcwd();
         chdir($this->phpci->buildPath);
@@ -74,11 +78,33 @@ class PackageBuild implements \PHPCI\Plugin
                     break;
             }
 
-            $success = $this->phpci->executeCommand($cmd, $this->directory, $filename);
+            $success = $this->phpci->executeCommand($cmd, $directory, $filename);
         }
 
         chdir($curdir);
 
         return $success;
     }
+
+	/**
+	 * @param string $string
+	 * @param Build $build
+	 * @param boolean $stripSpecialChars
+	 * @return mixed
+	 */
+	protected function replaceVariables($string, Build $build, $stripSpecialChars = TRUE) {
+		$branch = $build->getBranch();
+		$branch = str_replace('/', '-', $branch);
+
+		$replacedString = str_replace('%build.commit%', $build->getCommitId(), $string);
+		$replacedString = str_replace('%build.id%', $build->getId(), $replacedString);
+		$replacedString = str_replace('%build.branch%', $branch, $replacedString);
+		$replacedString = str_replace('%project.title%', $build->getProject()->getTitle(), $replacedString);
+		$replacedString = str_replace('%date%', date('Y-m-d'), $replacedString);
+		$replacedString = str_replace('%time%', date('Hi'), $replacedString);
+		if ($stripSpecialChars === TRUE) {
+			$replacedString = preg_replace('/([^a-zA-Z0-9_-]+)/', '', $replacedString);
+		}
+		return $replacedString;
+	}
 }


### PR DESCRIPTION
We had the problem that each commit in any branch creates a package. This creates a lot of waste we don't need. We just want packages of the master and develop branch. So with this option you are able to restrict this plugin to the given branches. The option expects an regular expression like this: 

```
  PackageBuild:
    directory: "/.../builds/%project.title%/%build.branch%/"
    filename: "build-%build.id%"
    allowedBranches: "^master$|^develop$"
    format: tar
```

Furthermore now the filename may also contain variables, which become replaced.