### PR TITLE
removes .affix from sidebar

### DIFF
--- a/PHPCI/View/Build/view.phtml
+++ b/PHPCI/View/Build/view.phtml
@@ -31,7 +31,7 @@
 
 <div class="row">
 	<div class="col-lg-3">
-        <div class="panel panel-default affix">
+        <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">Options</h4>
             </div>


### PR DESCRIPTION
Had issue on phone View/Build/view.phtml sits behind the content area and looks broken. Removed .affix and it now sits on top and I can now click quick links to navigate.  Also using fixed means parts of the navigation get cut off on smaller screens.

![broken](https://cloud.githubusercontent.com/assets/10221/4174559/bd7de2fc-3597-11e4-8d33-6e2052f55fce.png)

![fixed](https://cloud.githubusercontent.com/assets/10221/4174560/c4f10c58-3597-11e4-8a8b-a7a49af4f433.png)
