### PR TITLE
Fix line number in phpcs webplugin

### DIFF
--- a/public/assets/js/build-plugins/phpcs.js
+++ b/public/assets/js/build-plugins/phpcs.js
@@ -49,7 +49,7 @@ var phpcsPlugin = PHPCI.UiPlugin.extend({
 
             if (PHPCI.fileLinkTemplate) {
                 var fileLink = PHPCI.fileLinkTemplate.replace('{FILE}', file);
-                fileLink = fileLink.replace('{LINE}', errors[i].line_start);
+                fileLink = fileLink.replace('{LINE}', errors[i].line);
 
                 file = '<a target="_blank" href="'+fileLink+'">' + file + '</a>';
             }


### PR DESCRIPTION
Fix line number in phpcs plugin.
Now you can tap on line number and you'll send to gitlab/github repo.
