### PR TITLE
TapParser must capture skipped tests.

### DIFF
--- a/PHPCI/Plugin/Util/TapParser.php
+++ b/PHPCI/Plugin/Util/TapParser.php
@@ -8,6 +8,7 @@ class TapParser
     const TEST_LINE_PATTERN = '/(ok|not ok)\s+[0-9]+\s+\-\s+([^\n]+)::([^\n]+)/';
     const TEST_MESSAGE_PATTERN = '/message\:\s+\'([^\']+)\'/';
     const TEST_COVERAGE_PATTERN = '/Generating code coverage report/';
+    const TEST_SKIP_PATTERN = '/ok\s+[0-9]+\s+\-\s+#\s+SKIP/';
 
     /**
      * @var string
@@ -92,6 +93,8 @@ class TapParser
                 );
 
                 $rtn[] = $item;
+            } elseif (preg_match(self::TEST_SKIP_PATTERN, $line, $matches)) {
+                $rtn[] = array('message' => 'SKIP');
             } elseif (preg_match(self::TEST_MESSAGE_PATTERN, $line, $matches)) {
                 $rtn[count($rtn) - 1]['message'] = $matches[1];
             }

--- a/Tests/PHPCI/Plugin/Util/TapParserTest.php
+++ b/Tests/PHPCI/Plugin/Util/TapParserTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace PHPCI\Plugin\Tests\Util;
+
+use PHPCI\Plugin\Util\TapParser;
+
+class TapParserTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSkipped()
+    {
+        $content = <<<TAP
+TAP version 13
+ok 1 - SomeTest::testAnother
+ok 2 - # SKIP
+1..2
+TAP;
+        $parser = new TapParser($content);
+        $result = $parser->parse();
+
+        $this->assertEquals(array(
+            array('pass' => true, 'suite' => 'SomeTest', 'test' => 'testAnother'),
+            array('message' => 'SKIP'),
+        ), $result);
+
+        $this->assertEquals(0, $parser->getTotalFailures());
+    }
+}


### PR DESCRIPTION
This PR must be applied before PR #611, because we need to consider skipped tests too. I don't know if this is the best solution; other ideas are welcome.
