### PR TITLE
add commit message to pollcommand

### DIFF
--- a/PHPCI/Command/PollCommand.php
+++ b/PHPCI/Command/PollCommand.php
@@ -75,6 +75,7 @@ class PollCommand extends Command
 
             $last_commit = $commits['body'][0]['sha'];
             $last_committer = $commits['body'][0]['commit']['committer']['email'];
+            $message = $commits['body'][0]['commit']['message'];
 
             $this->logger->info("Last commit to github for " . $project->getTitle() . " is " . $last_commit);
 
@@ -89,6 +90,7 @@ class PollCommand extends Command
                 $build->setStatus(Build::STATUS_NEW);
                 $build->setBranch($project->getBranch());
                 $build->setCreated(new \DateTime());
+		$build->setCommitMessage($message);
                 if (!empty($last_committer)) {
                     $build->setCommitterEmail($last_committer);
                 }


### PR DESCRIPTION
Contribution Type: new feature
Primary Area: builder

Description of change: Add the github commit message to the build when using the PollCommand.

Description of solution: Retrieved the commit message from github.
