### PR TITLE
Allow PHP docblock checker to ignore anonymous functions.

### DIFF
--- a/PHPCI/Plugin/PhpDocblockChecker.php
+++ b/PHPCI/Plugin/PhpDocblockChecker.php
@@ -44,7 +44,7 @@ class PhpDocblockChecker implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
     protected $skipClasses = false;
     protected $skipMethods = false;
-    protected $skipAnonymousFunctions = false;
+    protected $skipAnonFunctions = false;
 
     public static function canExecute($stage, Builder $builder, Build $build)
     {
@@ -118,7 +118,7 @@ class PhpDocblockChecker implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
             $add .= ' --skip-methods';
         }
 
-        if ($this->skipAnonymousFunctions) {
+        if ($this->skipAnonFunctions) {
             $add .= ' --skip-anonymous-functions';
         }
 


### PR DESCRIPTION
Fixes #625. Requires merge of https://github.com/Block8/php-docblock-checker/pull/5 first.

This also requires the documentation (https://github.com/Block8/PHPCI/wiki/PHP-Docblock-Checker) to be updated to add **skip_anonymous_functions** as an option.
