### PR TITLE
fixed fatal for project without failed builds

### DIFF
--- a/PHPCI/View/SummaryTable.phtml
+++ b/PHPCI/View/SummaryTable.phtml
@@ -99,9 +99,7 @@ foreach($projects as $project):
                     All of the last <?php print count($builds[$project->getId()]); ?> builds passed.
 
                     <?php if (!is_null($failed[$project->getId()])): ?>
-                        <?php if (is_null($failed[$project->getId()]->getFinished())): ?>
-                            There are unfinished failed builds
-                        <?php else: ?>
+                        <?php if (!is_null($failed[$project->getId()]->getFinished())): ?>
                             The last failed build was
                             <?php print $failed[$project->getId()]->getFinished()->format('M j Y'); ?>
                         <?php endif; ?>


### PR DESCRIPTION
Error happening for me because $failed[$project->getId()]->getFinished() returns NULL

PHP Fatal error: Call to a member function format() on a non-object in /var/www/phpci/PHPCI/View/SummaryTable.phtml on line 103
