### PR TITLE
Logarithmic vertical scale for charts

### DIFF
--- a/public/assets/js/build-plugins/warnings.js
+++ b/public/assets/js/build-plugins/warnings.js
@@ -92,7 +92,7 @@ var warningsPlugin = ActiveBuild.UiPlugin.extend({
         var data = google.visualization.arrayToDataTable(data);
         var options = {
             hAxis: {title: 'Builds'},
-            vAxis: {title: 'Warnings / Errors'},
+            vAxis: {title: 'Warnings / Errors', logScale:true},
             backgroundColor: { fill: 'transparent' },
             height: 275,
             pointSize: 3


### PR DESCRIPTION
Since we have one diagram for multiple results, we may have PHPCS result giving 12000 errors, while PHPUnit gives 200 tests, and 1 failed test.. those numbers and their variation won't be very visible, unless we use logarithmic scale
