### PR TITLE
Fix gitlab url parse, make namespace not required.

### DIFF
--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -115,12 +115,12 @@ class ProjectService
         if ($project->getType() == 'gitlab') {
             $info = array();
 
-            if (preg_match('`^(.*)@(.*):([0-9]+)?/?(.*)/(.*)\.git`', $reference, $matches)) {
+            if (preg_match('`^(.*)@(.*):([0-9]+)?/?(.*)\.git`', $reference, $matches)) {
                 $info['user'] = $matches[1];
                 $info['domain'] = $matches[2];
                 $info['port'] = $matches[3];
 
-                $project->setReference($matches[4] . '/' . $matches[5]);
+                $project->setReference($matches[4]);
             }
 
             $project->setAccessInformation($info);


### PR DESCRIPTION
Gitlab version 5 and less doesn't require you to set project namespace.
I can create new project with url without namespace but it did not work and display php warnings on project page,
fix allow to create both project with namespace and without it.
