### PR TITLE
Fix public key wrap.

### DIFF
--- a/PHPCI/View/Project/view.phtml
+++ b/PHPCI/View/Project/view.phtml
@@ -91,7 +91,7 @@
         <?php if ($project->getSshPublicKey()): ?>
             <div class="box box-info">
                 <div class="box-header"><h3 class="box-title"><a data-toggle="collapse" data-parent="#accordion" href="#publicCollapse">Public Key</a></h3></div>
-                <div class="box-body" style="word-break: break-word;"><?php print $project->getSshPublicKey(); ?></div>
+                <div class="box-body" style="word-break: break-all;"><?php print $project->getSshPublicKey(); ?></div>
             </div>
         <?php endif; ?>
     </div>


### PR DESCRIPTION
Css property `word-break: break-word;` doens't exists, replaced with `word-break: break-all;`.
But it's a third issue related to public key block wrap (previous two: #408, #433). Admin LTE theme not support long code texts, and inline css its a bad usage, need to add or class `.word-wrap` and add `phpci.css` file to this page, as related to #433, or wrap public key into `<pre>` element and public key will be display in one line with horizontal scroll, like in #408. What will be better? 
