### PR TITLE
Fix css property word-break

### DIFF
--- a/PHPCI/View/Project/view.phtml
+++ b/PHPCI/View/Project/view.phtml
@@ -91,7 +91,7 @@
         <?php if ($project->getSshPublicKey()): ?>
             <div class="box box-info">
                 <div class="box-header"><h3 class="box-title"><a data-toggle="collapse" data-parent="#accordion" href="#publicCollapse">Public Key</a></h3></div>
-                <div class="box-body" style="word-break: break-word;"><?php print $project->getSshPublicKey(); ?></div>
+                <div class="box-body" style="word-break: break-all;"><?php print $project->getSshPublicKey(); ?></div>
             </div>
         <?php endif; ?>
     </div>


### PR DESCRIPTION
The value "break-word" don't work on Firefox.
https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
