### PR TITLE
Fix ignore bug in PhpParallelLint

### DIFF
--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -105,10 +105,11 @@ class PhpParallelLint implements \PHPCI\Plugin
      */
     protected function getFlags()
     {
-        $ignore = '';
-        if (count($this->ignore)) {
-            $ignore = ' --exclude ' . implode(' --exclude ', $this->ignore);
+        $ignoreFlags = array();
+        foreach ($this->ignore as $ignoreDir) {
+            $ignoreFlags[] = '--exclude "' . $this->phpci->buildPath . $ignoreDir . '"';
         }
+        $ignore = implode(' ', $ignoreFlags);
 
         return array($ignore);
     }


### PR DESCRIPTION
Apparently, when using a full path to the sources, the phplint --exclude parameter should also list full paths. This causes an issue where the ignore setting of the plugin isn't honored. This PR fixes it.
