### PR TITLE
Have the PhpUnit plugin reports an explicit error when no test are configured.

### DIFF
--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -142,6 +142,11 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     */
     public function execute()
     {
+        if (empty($this->xmlConfigFile) && empty($this->directory)) {
+            $this->phpci->logFailure('Neither configuration file nor test directory found.');
+            return false;
+        }
+
         $success = true;
 
         $this->phpci->logExecOutput(false);


### PR DESCRIPTION
... else if it reuses the output of a previous command and yells about invalid TAP format.
