### PR TITLE
In build view, only show meta of builds for the branch of the selected build.

### DIFF
--- a/PHPCI/Controller/BuildController.php
+++ b/PHPCI/Controller/BuildController.php
@@ -120,7 +120,7 @@ class BuildController extends \PHPCI\Controller
         $data = null;
 
         if ($key && $build) {
-            $data = $this->buildStore->getMeta($key, $build->getProjectId(), $buildId, $numBuilds);
+            $data = $this->buildStore->getMeta($key, $build->getProjectId(), $buildId, $build->getBranch(), $numBuilds);
         }
 
         die(json_encode($data));


### PR DESCRIPTION
In my opinion, it makes more to sense to show the stats about the previous builds in the same branch instead of any builds of the project.
