### PR TITLE
Update the CSS around the Public Key bloc to force word wrapping

### DIFF
--- a/PHPCI/View/Project/view.phtml
+++ b/PHPCI/View/Project/view.phtml
@@ -91,7 +91,7 @@
         <?php if ($project->getSshPublicKey()): ?>
             <div class="box box-info">
                 <div class="box-header"><h3 class="box-title"><a data-toggle="collapse" data-parent="#accordion" href="#publicCollapse">Public Key</a></h3></div>
-                <div class="box-body" style="word-break: break-word;"><?php print $project->getSshPublicKey(); ?></div>
+                <div class="box-body" style="word-break: break-all;"><?php print $project->getSshPublicKey(); ?></div>
             </div>
         <?php endif; ?>
     </div>


### PR DESCRIPTION
The public key bloc always add an horizontal scrollbar on the project page.
I add the break-all instead of break-word on that bloc because we have only 1 word :)
