### PR TITLE
Added ext-mcrypt as requirement in composer.json file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 
     "require": {
         "php": ">=5.3.8",
+        "ext-mcrypt": "*",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
         "block8/b8framework": "~1.0",


### PR DESCRIPTION
The PHP Mcrypt extension is required to allow PHPCI execution. Added this dependency in the ```composer.json``` file.