### PR TITLE
Resetting the status of a duplicated build

### DIFF
--- a/PHPCI/Service/BuildService.php
+++ b/PHPCI/Service/BuildService.php
@@ -100,6 +100,7 @@ class BuildService
         $build = new Build();
         $build->setValues($data);
         $build->setCreated(new \DateTime());
+        $build->setStatus(0);
 
         return $this->buildStore->save($build);
     }


### PR DESCRIPTION
When using SQL strict mode, mysql would complain that no default value of the status column is set. Setting the status to 0 before duplicating fixes this.