### PR TITLE
Using MySQL LONGTEXT for `meta_value`

### DIFF
--- a/PHPCI/Migrations/20140513143726_initial_migration.php
+++ b/PHPCI/Migrations/20140513143726_initial_migration.php
@@ -136,7 +136,7 @@ class InitialMigration extends AbstractMigration
         }
 
         if (!$table->hasColumn('meta_value')) {
-            $table->addColumn('meta_value', 'text');
+            $table->addColumn('meta_value', 'longtext');
         }
 
         if (!$table->hasIndex(array('build_id', 'meta_key'))) {


### PR DESCRIPTION
Some test suites (namely the larger ones, like laravel/framework) render much more output than can be stored by a MySQL TEXT field. Switching this to a LONGTEXT solves the issue.