### PR TITLE
Email plugin: use "default_mailto_address" as a fallback only.

### DIFF
--- a/PHPCI/Plugin/Email.php
+++ b/PHPCI/Plugin/Email.php
@@ -178,10 +178,10 @@ class Email implements \PHPCI\Plugin
             }
         }
 
-        if (isset($this->options['default_mailto_address'])) {
+        if (empty($addresses) && isset($this->options['default_mailto_address'])) {
             $addresses[] = $this->options['default_mailto_address'];
-            return $addresses;
         }
+
         return array_unique($addresses);
     }
 


### PR DESCRIPTION
I'm not sure what the intended behavior of the "default_mailto_address" parameter was, but right now it works exactly like "addresses".

With this change, the "default_mailto_address" is only used is the recipient list is empty, e.g. with no commiter email nor addresses.