### PR TITLE
Email plugin: remove duplicates from the list of recipients.

### DIFF
--- a/PHPCI/Plugin/Email.php
+++ b/PHPCI/Plugin/Email.php
@@ -182,7 +182,7 @@ class Email implements \PHPCI\Plugin
             $addresses[] = $this->options['default_mailto_address'];
             return $addresses;
         }
-        return $addresses;
+        return array_unique($addresses);
     }
 
     /**


### PR DESCRIPTION
Simply calls "array_unique" on the recipient list. This avoids sending duplicate emails if the committer is also in "addresses".