### PR TITLE
Convert tapString to UTF-8

### DIFF
--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -162,7 +162,7 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         }
 
         $tapString = $this->phpci->getLastOutput();
-        $tapString = mb_convert_encoding( $tapString, "UTF-8", "ISO-8859-1" );
+        $tapString = mb_convert_encoding($tapString, "UTF-8", "ISO-8859-1");
 
         try {
             $tapParser = new TapParser($tapString);

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -162,6 +162,7 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         }
 
         $tapString = $this->phpci->getLastOutput();
+        $tapString = mb_convert_encoding( $tapString, "UTF-8", "ISO-8859-1" );
 
         try {
             $tapParser = new TapParser($tapString);


### PR DESCRIPTION
My php_unit suite includes some non-UTF8 characters in the datasets that are passed to the tests. This was causing the `json_encode()` in `PHPCI\Model\Build::storeMeta()` to fail with `JSON_ERROR_UTF8`. I'm not sure if you have an abstraction for character type conversion or if there is a better place to convert this, but this is what fixed my issue. :smile: 