### PR TITLE
Try to fix #604

### DIFF
--- a/PHPCI/Model/Build/GitlabBuild.php
+++ b/PHPCI/Model/Build/GitlabBuild.php
@@ -56,22 +56,18 @@ class GitlabBuild extends RemoteGitBuild
     */
     protected function getCloneUrl()
     {
-        $key = trim($this->getProject()->getSshPrivateKey());
+        $protocol = $this->getProject()->getAccessInformation('protocol');
+        $user = $this->getProject()->getAccessInformation("user");
+        $domain = $this->getProject()->getAccessInformation("domain");
+        $port = $this->getProject()->getAccessInformation('port');
+        $reference = $this->getProject()->getReference();
 
-        if (!empty($key)) {
-            $user = $this->getProject()->getAccessInformation("user");
-            $domain = $this->getProject()->getAccessInformation("domain");
-            $port = $this->getProject()->getAccessInformation('port');
+        $protocol .= '://';
+        if (!empty($user)) { $user .= '@'; }
+        if (!empty($port)) { $port = ':' . $port . '/'; } else { $port = ':'; }
 
-            $url = $user . '@' . $domain . ':';
+        $url = sprintf('%s%s%s%s%s.git', $protocol, $user, $domain, $port, $reference);
 
-            if (!empty($port)) {
-                $url .= $port . '/';
-            }
-
-            $url .= $this->getProject()->getReference() . '.git';
-
-            return $url;
-        }
+        return $url;
     }
 }

--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -115,12 +115,17 @@ class ProjectService
         if ($project->getType() == 'gitlab') {
             $info = array();
 
-            if (preg_match('`^(.+)@(.+):([0-9]*)\/?(.+)\.git`', $reference, $matches)) {
-                $info['user'] = $matches[1];
-                $info['domain'] = $matches[2];
-                $info['port'] = $matches[3];
+            if (preg_match('`(?:(https?|ssh):\/\/)?((.+)@)?(.+):([0-9]*)\/?(.+)\.git`', $reference, $matches)) {
+                $info['protocol'] = !empty($matches[1]) ? $matches[1] : 'ssh';
+                $info['user'] = $matches[3];
+                $info['domain'] = $matches[4];
+                $info['port'] = $matches[5];
 
-                $project->setReference($matches[4]);
+                if ('ssh' === $info['protocol'] && empty($info['user'])) {
+                    $info['user'] = 'git';
+                }
+
+                $project->setReference($matches[6]);
             }
 
             $project->setAccessInformation($info);


### PR DESCRIPTION
Try to fix #604.
Support pattern of gitlab reference that starts with 'http://', 'https://' or 'ssh://'.
For example:
- `http://localhost/group/project.git`
- `ssh://git@localhost/group/project.git`
- `http://localhost:2222/group/project.git`
- `ssh://git@localhost:2222/group/project.git`

Original pattern is also supported:
`git@localhost:group/project.git`