### PR TITLE
Fixed issue #575: Removed unused $buildPath property.

### DIFF
--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -46,12 +46,6 @@ abstract class BaseCommandExecutor implements CommandExecutor
     protected $rootDir;
 
     /**
-     * Current build path
-     * @var string
-     */
-    protected $buildPath;
-
-    /**
      * @param BuildLogger $logger
      * @param string      $rootDir
      * @param bool        $quiet
@@ -92,7 +86,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
         $pipes = array();
 
-        $process = proc_open($command, $descriptorSpec, $pipes, dirname($this->buildPath), null);
+        $process = proc_open($command, $descriptorSpec, $pipes, null, null);
 
         if (is_resource($process)) {
             fclose($pipes[0]);

--- a/PHPCI/Helper/SshKey.php
+++ b/PHPCI/Helper/SshKey.php
@@ -63,7 +63,7 @@ class SshKey
      */
     public function canGenerateKeys()
     {
-        $keygen = @shell_exec('ssh-keygen -h');
+        $keygen = @shell_exec('ssh-keygen --help');
         $canGenerateKeys = !empty($keygen);
 
         return $canGenerateKeys;

--- a/PHPCI/Migrations/20150115154849_build_meta_medium_text.php
+++ b/PHPCI/Migrations/20150115154849_build_meta_medium_text.php
@@ -1,0 +1,39 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class BuildMetaMediumText extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     *
+     * Uncomment this method if you would like to use it.
+     *
+    public function change()
+    {
+    }
+    */
+    
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $table = $this->table('build_meta');
+        $table->changeColumn('meta_value', 'mediumtext');
+        $table->save();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $table = $this->table('build_meta');
+        $table->changeColumn('meta_value', 'text');
+        $table->save();
+    }
+}


### PR DESCRIPTION
Since the $buildPath is protected and not used in the class or its descendants, I removed it.

Also I fixed issue #575, where createprocess does fails because dirname(null) returns "".