### PR TITLE
Fix issue Phing targets are not executed in the build dir

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -337,7 +337,7 @@ class Builder implements LoggerAwareInterface
         $this->buildLogger->log($message, $level, $context);
     }
 
-   /**
+    /**
      * Add a success-coloured message to the log.
      * @param string
      */

--- a/PHPCI/Controller/BuildController.php
+++ b/PHPCI/Controller/BuildController.php
@@ -180,38 +180,48 @@ class BuildController extends \PHPCI\Controller
 
     /**
      * Parse log for unix colours and replace with HTML.
-     * 
+     *
      * @link http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
      * @param string $log Output
      */
     protected function cleanLog($log)
     {
         $shellColours = [
-        '[0;30m' => '<span style="color: black">',
-        '[0;31m' => '<span style="color: red">',
-        '[0;32m' => '<span style="color: green">',
-        '[0;33m' => '<span style="color: brown">',
-        '[0;34m' => '<span style="color: blue">',
-        '[0;35m' => '<span style="color: purple">',
-        '[0;36m' => '<span style="color: cyan">',
-        '[0;37m' => '<span style="color: lightGray">',
-        '[1;31m' => '<span style="color: lightRed">',
-        '[1;32m' => '<span style="color: lightGreen">',
-        '[1;33m' => '<span style="color: yellow">',
-        '[1;34m' => '<span style="color: lightBlue">',
-        '[1;35m' => '<span style="color: lightPurple">',
-        '[1;36m' => '<span style="color: lightCyan">',
-        '[1;37m' => '<span style="color: white">',
-        '[0m' => '</span>',
+            '[0;30m' => '<span style="color: black">',
+            '[0;31m' => '<span style="color: red">',
+            '[0;32m' => '<span style="color: green">',
+            '[0;33m' => '<span style="color: brown">',
+            '[0;34m' => '<span style="color: blue">',
+            '[0;35m' => '<span style="color: purple">',
+            '[0;36m' => '<span style="color: cyan">',
+            '[0;37m' => '<span style="color: lightGray">',
+            '[1;31m' => '<span style="color: lightRed">',
+            '[1;32m' => '<span style="color: lightGreen">',
+            '[1;33m' => '<span style="color: yellow">',
+            '[1;34m' => '<span style="color: lightBlue">',
+            '[1;35m' => '<span style="color: lightPurple">',
+            '[1;36m' => '<span style="color: lightCyan">',
+            '[1;37m' => '<span style="color: white">',
+            '[0m'    => '</span>',
         ];
-               $log = str_replace('[0;31m',
-                           '<span style="color: red">',
-                           $log);
-        $log = str_replace('[0m',
-                           '</span>',
-                           $log);
 
-        return str_replace(array_keys($shellColours), $shellColours, $log);
+        $log = str_replace(
+            '[0;31m',
+            '<span style="color: red">',
+            $log
+        );
+
+        $log = str_replace(
+            '[0m',
+            '</span>',
+            $log
+        );
+
+        return str_replace(
+            array_keys($shellColours),
+            $shellColours,
+            $log
+        );
     }
 
     /**

--- a/PHPCI/Controller/BuildController.php
+++ b/PHPCI/Controller/BuildController.php
@@ -179,15 +179,39 @@ class BuildController extends \PHPCI\Controller
     }
 
     /**
-    * Parse log for unix colours and replace with HTML.
-    */
+     * Parse log for unix colours and replace with HTML.
+     * 
+     * @link http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
+     * @param string $log Output
+     */
     protected function cleanLog($log)
     {
-        $log = str_replace('[0;32m', '<span style="color: green">', $log);
-        $log = str_replace('[0;31m', '<span style="color: red">', $log);
-        $log = str_replace('[0m', '</span>', $log);
+        $shellColours = [
+        '[0;30m' => '<span style="color: black">',
+        '[0;31m' => '<span style="color: red">',
+        '[0;32m' => '<span style="color: green">',
+        '[0;33m' => '<span style="color: brown">',
+        '[0;34m' => '<span style="color: blue">',
+        '[0;35m' => '<span style="color: purple">',
+        '[0;36m' => '<span style="color: cyan">',
+        '[0;37m' => '<span style="color: lightGray">',
+        '[1;31m' => '<span style="color: lightRed">',
+        '[1;32m' => '<span style="color: lightGreen">',
+        '[1;33m' => '<span style="color: yellow">',
+        '[1;34m' => '<span style="color: lightBlue">',
+        '[1;35m' => '<span style="color: lightPurple">',
+        '[1;36m' => '<span style="color: lightCyan">',
+        '[1;37m' => '<span style="color: white">',
+        '[0m' => '</span>',
+        ];
+               $log = str_replace('[0;31m',
+                           '<span style="color: red">',
+                           $log);
+        $log = str_replace('[0m',
+                           '</span>',
+                           $log);
 
-        return $log;
+        return str_replace(array_keys($shellColours), $shellColours, $log);
     }
 
     /**

--- a/PHPCI/Controller/BuildController.php
+++ b/PHPCI/Controller/BuildController.php
@@ -205,18 +205,6 @@ class BuildController extends \PHPCI\Controller
             '[0m'    => '</span>',
         ];
 
-        $log = str_replace(
-            '[0;31m',
-            '<span style="color: red">',
-            $log
-        );
-
-        $log = str_replace(
-            '[0m',
-            '</span>',
-            $log
-        );
-
         return str_replace(
             array_keys($shellColours),
             $shellColours,

--- a/PHPCI/Controller/PluginController.php
+++ b/PHPCI/Controller/PluginController.php
@@ -124,7 +124,7 @@ class PluginController extends \PHPCI\Controller
 
     /**
      * Convert array to json and save composer.json
-     * 
+     *
      * @param $array
      */
     protected function setComposerJson($array)

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -160,7 +160,6 @@ class WebhookController extends \PHPCI\Controller
         }
 
         try {
-
             if (isset($payload['commits']) && is_array($payload['commits'])) {
                 // If we have a list of commits, then add them all as builds to be tested:
 
@@ -255,13 +254,10 @@ class WebhookController extends \PHPCI\Controller
         $payload = json_decode($payloadString, true);
 
         try {
-
-
             // build on merge request events
             if (isset($payload['object_kind']) && $payload['object_kind'] == 'merge_request') {
                 $attributes = $payload['object_attributes'];
                 if ($attributes['state'] == 'opened' || $attributes['state'] == 'reopened') {
-
                     $branch = $attributes['source_branch'];
                     $commit = $attributes['last_commit'];
                     $committer = $commit['author']['email'];

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -86,7 +86,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
              * show the command to execute in purple
              * @link http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
              */
-            $this->logger->log([null, null, "\033[0;35mExecuting: {$command}\033[0m", null]);
+            $this->logger->log([null, null, "\033[0;35mExecuting: " . $command . "\033[0m", null]);
         }
         
 
@@ -117,7 +117,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
         }
 
         if (!empty($this->lastError)) {
-            $this->logger->log("\033[0;31m{$this->lastError}\033[0m", LogLevel::ERROR);
+            $this->logger->log("\033[0;31m" . $this->lastError . "\033[0m", LogLevel::ERROR);
         }
 
         $rtn = false;
@@ -133,14 +133,18 @@ abstract class BaseCommandExecutor implements CommandExecutor
      * Manage the standard output of a process execution flushing data in
      * realtime
      *
+     * @param resource $process
      * @param array $pipes proc_open pipes
      * @param boolean $shouldOutput
+     * @return boolean
      */
     protected function manageExecutionStandardOutput($process, $pipes, $shouldOutput)
     {
         $status = false;
 
-        if (is_resource($process)) {
+        if (is_resource($process) and
+            is_array($pipes) and
+            isset($pipes[1])) {
             /**
              * don't wait to the end of the process to output stdout
              */

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -104,12 +104,10 @@ abstract class BaseCommandExecutor implements CommandExecutor
         $process = proc_open($command, $descriptorSpec, $pipes, dirname($this->buildPath), null);
 
         if (is_resource($process)) {
-
             /**
              * don't wait to the end of the process to output stdout
              */
-            while( !feof($pipes[1])) {
-
+            while (!feof($pipes[1])) {
                 /**
                  * sets string lengh to 64M because outputs of processes
                  * are managed by plugins
@@ -195,7 +193,6 @@ abstract class BaseCommandExecutor implements CommandExecutor
             $this->logger->log(Lang::get('looking_for_binary', $bin), LogLevel::DEBUG);
 
             if (is_dir($composerBin) && is_file($composerBin.'/'.$bin)) {
-
                 $this->logger->log(Lang::get('found_in_path', $composerBin, $bin), LogLevel::DEBUG);
                 $binaryPath = $composerBin . '/' . $bin;
                 break;

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -121,14 +121,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
                     break;
                 }
 
-                /**
-                 * remove the filters, we want to view in console the colours
-                 * when we execute :
-                 *    ./console phpci:run-builds
-                 * oldest way:
-                 *    //$aStdOut = array_filter(explode(PHP_EOL, $stdOut));
-                 */
-                $aStdOut = explode(PHP_EOL, $stdOut);
+                $aStdOut = array_filter(explode(PHP_EOL, $stdOut));
 
                 $this->lastOutput = array_merge($this->lastOutput, $aStdOut);
                

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -81,7 +81,14 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
         if ($this->quiet) {
             $this->logger->log('Executing: ' . $command);
+        } else {
+            /**
+             * show the command to execute in purple
+             * @link http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
+             */
+            $this->logger->log([null, null, "\033[0;35mExecuting: {$command}\033[0m", null]);
         }
+        
 
         $status = 0;
         $descriptorSpec = array(
@@ -109,7 +116,14 @@ abstract class BaseCommandExecutor implements CommandExecutor
                     break;
                 }
 
-                $aStdOut = array_filter(explode(PHP_EOL, $stdOut));
+                /**
+                 * remove the filters, we want to view in console the colours
+                 * when we execute :
+                 *    ./console phpci:run-builds
+                 * oldest way:
+                 *    //$aStdOut = array_filter(explode(PHP_EOL, $stdOut));
+                 */
+                $aStdOut = explode(PHP_EOL, $stdOut);
 
                 $this->lastOutput = array_merge($this->lastOutput, $aStdOut);
                
@@ -136,7 +150,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
         }
 
         if (!empty($this->lastError)) {
-            $this->logger->log("\033[0;31m" . $this->lastError . "\033[0m", LogLevel::ERROR);
+            $this->logger->log("\033[0;31m{$this->lastError}\033[0m", LogLevel::ERROR);
         }
 
         $rtn = false;

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -110,7 +110,12 @@ abstract class BaseCommandExecutor implements CommandExecutor
              */
             while( !feof($pipes[1])) {
 
-                $stdOut = fgets($pipes[1], 4096);
+                /**
+                 * sets string lengh to 64M because outputs of processes
+                 * are managed by plugins
+                 * @todo study the case of big strings.
+                 */
+                $stdOut = fgets($pipes[1], 67108864);
 
                 if (strlen($stdOut) === 0) {
                     break;

--- a/PHPCI/Helper/Github.php
+++ b/PHPCI/Helper/Github.php
@@ -48,15 +48,12 @@ class Github
         $res = $http->get($url, $params);
 
         foreach ($res['body'] as $item) {
-
             $results[] = $item;
 
         }
 
         foreach ($res['headers'] as $header) {
-
             if (preg_match('/^Link: <([^>]+)>; rel="next"/', $header, $r)) {
-
                 $host = parse_url($r[1]);
 
                 parse_str($host['query'], $params);

--- a/PHPCI/Helper/LoginIsDisabled.php
+++ b/PHPCI/Helper/LoginIsDisabled.php
@@ -18,7 +18,7 @@ namespace PHPCI\Helper;
 class LoginIsDisabled
 {
     /**
-     * Checks if 
+     * Checks if
      * @param $method
      * @param array $params
      * @return mixed|null

--- a/PHPCI/Logging/BuildLogger.php
+++ b/PHPCI/Logging/BuildLogger.php
@@ -67,7 +67,7 @@ class BuildLogger implements LoggerAwareInterface
         }
     }
 
-   /**
+    /**
      * Add a success-coloured message to the log.
      * @param string
      */

--- a/PHPCI/Logging/Handler.php
+++ b/PHPCI/Logging/Handler.php
@@ -70,7 +70,6 @@ class Handler
     public function handleError($level, $message, $file, $line)
     {
         if (error_reporting() & $level) {
-
             $exception_level = isset($this->levels[$level]) ? $this->levels[$level] : $level;
 
             throw new \ErrorException(
@@ -140,7 +139,6 @@ class Handler
     protected function log(\Exception $exception)
     {
         if (null !== $this->logger) {
-
             $message = sprintf(
                 '%s: %s (uncaught exception) at %s line %s',
                 get_class($exception),

--- a/PHPCI/Model/Build.php
+++ b/PHPCI/Model/Build.php
@@ -93,7 +93,7 @@ class Build extends BuildBase
      * @param Builder $builder
      * @param string  $buildPath
      *
-     * @return bool
+     * @return array|bool
      */
     protected function handleConfig(Builder $builder, $buildPath)
     {
@@ -120,7 +120,8 @@ class Build extends BuildBase
         }
 
         $builder->setConfigArray($build_config);
-        return true;
+        
+        return $build_config;
     }
 
     /**

--- a/PHPCI/Model/Build.php
+++ b/PHPCI/Model/Build.php
@@ -99,14 +99,14 @@ class Build extends BuildBase
     {
         $build_config = null;
 
-        // Try phpci.yml first:
-        if (is_file($buildPath . '/phpci.yml')) {
-            $build_config = file_get_contents($buildPath . '/phpci.yml');
-        }
-
         // Try getting the project build config from the database:
         if (empty($build_config)) {
             $build_config = $this->getProject()->getBuildConfig();
+        }
+
+        // Try phpci.yml first:
+        if (empty($build_config) and is_file($buildPath . '/phpci.yml')) {
+            $build_config = file_get_contents($buildPath . '/phpci.yml');
         }
 
         // Fall back to zero config plugins:

--- a/PHPCI/Model/Build/LocalBuild.php
+++ b/PHPCI/Model/Build/LocalBuild.php
@@ -37,20 +37,20 @@ class LocalBuild extends Build
 
         $buildSettings = $this->handleConfig($builder, $reference);
         if (is_array($buildSettings) and isset($buildSettings['build_settings'])) {
-            $buildSettings = $buildSettings['build_settings']; 
+            $buildSettings = $buildSettings['build_settings'];
         } else {
             return false;
         }
 
         if (isset($buildSettings['prefer_symlink']) && $buildSettings['prefer_symlink'] === true) {
             return $this->handleSymlink($builder, $reference, $buildPath);
-        } elseif(isset($buildSettings['prefer_rsync']) and $buildSettings['prefer_rsync'] === true) { 
+        } elseif (isset($buildSettings['prefer_rsync']) and $buildSettings['prefer_rsync'] === true) {
             if (isset($buildSettings['ignore'])) {
                 $exclude = '--exclude ' . implode(' --exclude ', $buildSettings['ignore']);
             } else {
                 $exclude = "";
             }
-            $cmd = 'rsync -qav %s "%s/" "%s"'; 
+            $cmd = 'rsync -qav %s "%s/" "%s"';
             $builder->executeCommand($cmd, $exclude, $reference, $buildPath);
         } else {
             $cmd = 'cp -Rf "%s" "%s/"';

--- a/PHPCI/Model/Build/LocalBuild.php
+++ b/PHPCI/Model/Build/LocalBuild.php
@@ -42,25 +42,95 @@ class LocalBuild extends Build
             return false;
         }
 
+        return $this->handleCreateWorkingCopy(
+            $builder,
+            $buildPath,
+            $reference,
+            $buildSettings
+        );
+    }
+
+    /**
+     * Handle the way to create a working copy
+     *
+     * @param Builder $builder
+     * @param string $buildPath
+     * @param string $reference
+     * @param array $buildSettings
+     * @return boolean
+     */
+    protected function handleCreateWorkingCopy(Builder $builder, $buildPath, $reference, $buildSettings)
+    {
         if (isset($buildSettings['prefer_symlink']) && $buildSettings['prefer_symlink'] === true) {
-            return $this->handleSymlink($builder, $reference, $buildPath);
+            return $this->handleSymlink(
+                $builder,
+                $reference,
+                $buildPath
+            );
         } elseif (isset($buildSettings['prefer_rsync']) and $buildSettings['prefer_rsync'] === true) {
-            if (isset($buildSettings['ignore'])) {
-                $exclude = '--exclude ' . implode(' --exclude ', $buildSettings['ignore']);
-            } else {
-                $exclude = "";
-            }
-            $cmd = 'rsync -qav %s "%s/" "%s"';
-            $builder->executeCommand($cmd, $exclude, $reference, $buildPath);
+            return $this->createWorkingCopyRsync(
+                $builder,
+                $buildPath,
+                $reference,
+                $buildSettings
+            );
         } else {
-            $cmd = 'cp -Rf "%s" "%s/"';
-            if (IS_WIN) {
-                $cmd = 'xcopy /E /Y "%s" "%s/*"';
-            }
-            $builder->executeCommand($cmd, $reference, $buildPath);
+            return $this->createWorkingCopyDefault(
+                $builder,
+                $reference,
+                $buildPath
+            );
+        }
+    }
+    /**
+     * Create working copy with rsync
+     *
+     * @param Builder $builder
+     * @param string $buildPath
+     * @param string $reference
+     * @param array $buildSettings
+     */
+    protected function createWorkingCopyRsync(Builder $builder, $buildPath, $reference, $buildSettings)
+    {
+        if (isset($buildSettings['ignore'])) {
+            $exclude = '--exclude ';
+            $exclude .= implode(
+                ' --exclude ',
+                $buildSettings['ignore']
+            );
+        } else {
+            $exclude = "";
+        }
+        $cmd = 'rsync -qav %s "%s/" "%s"';
+
+        return $builder->executeCommand(
+            $cmd,
+            $exclude,
+            $reference,
+            $buildPath
+        );
+    }
+
+
+    /**
+     * Create working copy copying all the files
+     *
+     * @param Builder $builder
+     * @param string $reference
+     * @param string $buildPath
+     */
+    protected function createWorkingCopyDefault(Builder $builder, $reference, $buildPath)
+    {
+        $cmd = 'cp -Rf "%s" "%s/"';
+        if (IS_WIN) {
+            $cmd = 'xcopy /E /Y "%s" "%s/*"';
         }
 
-        return true;
+        return $builder->executeCommand(
+            $cmd,
+            $reference,
+            $buildPath
+        );
     }
 
     /**

--- a/PHPCI/Model/Build/LocalBuild.php
+++ b/PHPCI/Model/Build/LocalBuild.php
@@ -36,13 +36,22 @@ class LocalBuild extends Build
         }
 
         $buildSettings = $this->handleConfig($builder, $reference);
-
-        if ($buildSettings === false) {
+        if (is_array($buildSettings) and isset($buildSettings['build_settings'])) {
+            $buildSettings = $buildSettings['build_settings']; 
+        } else {
             return false;
         }
 
         if (isset($buildSettings['prefer_symlink']) && $buildSettings['prefer_symlink'] === true) {
             return $this->handleSymlink($builder, $reference, $buildPath);
+        } elseif(isset($buildSettings['prefer_rsync']) and $buildSettings['prefer_rsync'] === true) { 
+            if (isset($buildSettings['ignore'])) {
+                $exclude = '--exclude ' . implode(' --exclude ', $buildSettings['ignore']);
+            } else {
+                $exclude = "";
+            }
+            $cmd = 'rsync -qav %s "%s/" "%s"'; 
+            $builder->executeCommand($cmd, $exclude, $reference, $buildPath);
         } else {
             $cmd = 'cp -Rf "%s" "%s/"';
             if (IS_WIN) {

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -82,7 +82,6 @@ class Codeception implements \PHPCI\Plugin
         if (is_array($configPath)) {
             return $this->recurseArg($configPath, array($this, "runConfigFile"));
         } else {
-
             $codecept = $this->phpci->findBinary('codecept');
 
             if (!$codecept) {

--- a/PHPCI/Plugin/Phar.php
+++ b/PHPCI/Plugin/Phar.php
@@ -227,7 +227,6 @@ class Phar implements \PHPCI\Plugin
         $success = false;
 
         try {
-
             $phar = new PHPPhar($this->getDirectory() . '/' . $this->getFilename(), 0, $this->getFilename());
             $phar->buildFromDirectory($this->getPHPCI()->buildPath, $this->getRegExp());
 

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -218,7 +218,7 @@ class Phing implements \PHPCI\Plugin
          * @ticket 748
          */
         if (!isset($this->properties['project.basedir'])) {
-           $this->properties['project.basedir'] = $this->getDirectory(); 
+            $this->properties['project.basedir'] = $this->getDirectory();
         }
 
         $propertiesString = array();

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -213,8 +213,12 @@ class Phing implements \PHPCI\Plugin
      */
     public function propertiesToString()
     {
-        if (empty($this->properties)) {
-            return '';
+        /**
+         * fix the problem when execute phing out of the build dir
+         * @ticket 748
+         */
+        if (!isset($this->properties['project.basedir'])) {
+           $this->properties['project.basedir'] = $this->getDirectory(); 
         }
 
         $propertiesString = array();

--- a/PHPCI/Plugin/PhpTalLint.php
+++ b/PHPCI/Plugin/PhpTalLint.php
@@ -212,7 +212,6 @@ class PhpTalLint implements PHPCI\Plugin
 
         // FIXME: This is very messy, clean it up
         if (preg_match('/Found (.+?) (error|warning)/i', $output, $matches)) {
-
             $rows = explode(PHP_EOL, $output);
 
             unset($rows[0]);

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -50,6 +50,11 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     protected $xmlConfigFile;
 
     /**
+     * @var bool $logExecOutput Allow to configure if we want output execution to log.
+     */
+    protected $logExecOutput = false;
+
+    /**
      * Check if this plugin can be executed.
      * @param $stage
      * @param Builder $builder
@@ -135,6 +140,11 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         if (isset($options['coverage'])) {
             $this->coverage = " --coverage-html {$options['coverage']} ";
         }
+    
+        if (isset($options['log_exec_output'])) {
+            $this->logExecOutput = $options['log_exec_output'];
+        }
+
     }
 
     /**
@@ -149,7 +159,7 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
         $success = true;
 
-        $this->phpci->logExecOutput(false);
+        $this->phpci->logExecOutput($this->logExecOutput);
 
         // Run any config files first. This can be either a single value or an array.
         if ($this->xmlConfigFile !== null) {

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -280,4 +280,24 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         }
         return $success;
     }
+
+    /**
+     * Returns Build
+     *
+     * @return Build
+     */
+    public function getBuild()
+    {
+        return $this->build;
+    }
+
+    /**
+     * Returns Phpci
+     *
+     * @return Phpci
+     */
+    public function getPHPCI()
+    {
+        return $this->phpci;
+    }
 }

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -128,34 +128,34 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     protected function setOptions($options)
     {
-        foreach ($options as $option) {
+        foreach ($options as $option => $value) {
             switch ($option) {
                 case 'directory':
-                    $this->directory = $options['directory'];
+                    $this->directory = $value;
                     break;
 
                 case 'config':
-                    $this->xmlConfigFile = $options['config'];
+                    $this->xmlConfigFile = $value;
                     break;
 
                 case 'run_from':
-                    $this->runFrom = $options['run_from'];
+                    $this->runFrom = $value;
                     break;
 
                 case 'args':
-                    $this->args = $this->phpci->interpolate($options['args']);
+                    $this->args = $this->phpci->interpolate($value);
                     break;
 
                 case 'path':
-                    $this->args = $this->phpci->interpolate($options['args']);
+                    $this->args = $this->phpci->interpolate($value);
                     break;
 
                 case 'coverage':
-                    $this->coverage = " --coverage-html {$options['coverage']} ";
+                    $this->coverage = " --coverage-html {$value} ";
                     break;
 
                 case 'log_exec_output':
-                    $this->logExecOutput = $options['log_exec_output'];
+                    $this->logExecOutput = $value;
                     break;
             }
         }

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -117,34 +117,48 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
             $this->xmlConfigFile = self::findConfigFile($phpci->buildPath);
         }
 
-        if (isset($options['directory'])) {
-            $this->directory = $options['directory'];
-        }
+        $this->setOptions($options);
+        
+    }
 
-        if (isset($options['config'])) {
-            $this->xmlConfigFile = $options['config'];
-        }
+    /**
+     * Set options in properties
+     *
+     * @param array $options
+     */
+    protected function setOptions($options)
+    {
+        foreach ($options as $option) {
+            switch ($option) {
+                case 'directory':
+                    $this->directory = $options['directory'];
+                    break;
 
-        if (isset($options['run_from'])) {
-            $this->runFrom = $options['run_from'];
-        }
+                case 'config':
+                    $this->xmlConfigFile = $options['config'];
+                    break;
 
-        if (isset($options['args'])) {
-            $this->args = $this->phpci->interpolate($options['args']);
-        }
+                case 'run_from':
+                    $this->runFrom = $options['run_from'];
+                    break;
 
-        if (isset($options['path'])) {
-            $this->path = $options['path'];
-        }
+                case 'args':
+                    $this->args = $this->phpci->interpolate($options['args']);
+                    break;
 
-        if (isset($options['coverage'])) {
-            $this->coverage = " --coverage-html {$options['coverage']} ";
-        }
-    
-        if (isset($options['log_exec_output'])) {
-            $this->logExecOutput = $options['log_exec_output'];
-        }
+                case 'path':
+                    $this->args = $this->phpci->interpolate($options['args']);
+                    break;
 
+                case 'coverage':
+                    $this->coverage = " --coverage-html {$options['coverage']} ";
+                    break;
+
+                case 'log_exec_output':
+                    $this->logExecOutput = $options['log_exec_output'];
+                    break;
+            }
+        }
     }
 
     /**

--- a/PHPCI/Plugin/Util/Executor.php
+++ b/PHPCI/Plugin/Util/Executor.php
@@ -55,12 +55,10 @@ class Executor
 
             // Try and execute it:
             if ($this->executePlugin($plugin, $options)) {
-
                 // Execution was successful:
                 $this->logger->logSuccess(Lang::get('plugin_success'));
 
             } else {
-
                 // If we're in the "test" stage and the plugin is not allowed to fail,
                 // then mark the build as failed:
                 if ($stage == 'test' && !$options['allow_failures']) {

--- a/PHPCI/Plugin/Util/FilesPluginInformation.php
+++ b/PHPCI/Plugin/Util/FilesPluginInformation.php
@@ -67,7 +67,7 @@ class FilesPluginInformation implements InstalledPluginInformation
     {
         return array_map(
             function ($plugin) {
-               return $plugin->class;
+                return $plugin->class;
             },
             $this->getInstalledPlugins()
         );

--- a/PHPCI/Service/BuildService.php
+++ b/PHPCI/Service/BuildService.php
@@ -97,6 +97,11 @@ class BuildService
         unset($data['started']);
         unset($data['finished']);
 
+        /**
+         * Fix SQLSTATE[HY000]: General error: 1364 Field 'status' doesn't have a default value
+         */
+        $data['status'] = 0;
+
         $build = new Build();
         $build->setValues($data);
         $build->setCreated(new \DateTime());

--- a/Tests/PHPCI/Plugin/PhpUnitTest.php
+++ b/Tests/PHPCI/Plugin/PhpUnitTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace PHPCI\Plugin\Tests;
+
+use PHPCI\Plugin\PhpUnit as PhpUnitPlugin;
+use RuntimeException;
+
+class PhpUnitTest extends \PHPUnit_Framework_TestCase
+{
+    protected function getPlugin(array $options = array())
+    {
+        $build = $this
+            ->getMockBuilder('PHPCI\Model\Build')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $phpci = $this
+            ->getMockBuilder('PHPCI\Builder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return new PhpUnitPlugin($phpci, $build, $options);
+    }
+
+    public function testPlugin()
+    {
+        $plugin = $this->getPlugin(['coverage' => 'directory']);
+        $this->assertInstanceOf('PHPCI\Plugin', $plugin);
+        $this->assertInstanceOf('PHPCI\Model\Build', $plugin->getBuild());
+        $this->assertInstanceOf('PHPCI\Builder', $plugin->getPHPCI());
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -31,8 +31,10 @@ if (!file_exists($configFile)) {
     }
 }
 
+    
+$config = new b8\Config($conf);
+
 if (file_exists($configFile)) {
-    $config = new b8\Config($conf);
     $config->loadYaml($configFile);
 }
 


### PR DESCRIPTION
See comments in the issues #746 and #748 and commits 56f04d9 and ed13ec5.

Other commits without linked official issue has been attached to the pull request. Maybe could be interesting for the project:

* #746 fix Field 'status' doesn't have a default value when click "Rebuild Now"
* #748 fix Phing targets are not executed in the build dir
* Fix issue build_settings ignored in createWorkingCopy.
* Add a new option in the **build** section: prefer_rsync that exclude the ignored folders in the copy when the project is hosted in **Local Path**.
* Flush stdout while executing a step, don't wait at the end of the execution.
* Improve to log more colours from console stdout than red and green.
* Allow to override phpci.yml in a concrete build.
* Fix phpunit bootstrap that crash if not exists a config file.
