### PR TITLE
Add Jasmine & Pho testing support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "behat/behat": "Behat BDD Testing",
         "hipchat/hipchat-php": "Hipchat integration",
         "phptal/phptal": "PHPTAL templating engine",
-        "maknz/slack": "Slack integration"
+        "maknz/slack": "Slack integration",
+        "austp/phpci-pho-plugin": "Pho BDD Testing"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "hipchat/hipchat-php": "Hipchat integration",
         "phptal/phptal": "PHPTAL templating engine",
         "maknz/slack": "Slack integration",
-        "austp/phpci-pho-plugin": "Pho BDD Testing"
+        "austp/phpci-pho-plugin": "Pho BDD Testing",
+        "austp/phpci-jasmine-node-plugin": "Jasmine BDD Testing via jasmine-node"
     }
 }


### PR DESCRIPTION
Contribution Type: new plugins
Primary Area: plugins

Adding a link for a new [plugin](https://github.com/austp/phpci-pho-plugin) to support [pho](https://github.com/danielstjules/pho)
Adding a link for a new [plugin](https://github.com/austp/phpci-jasmine-node-plugin) to support [Jasmine](https://jasmine.github.io) via [jasmine-node](https://github.com/mhevery/jasmine-node)