### PR TITLE
ApiGen Plugin

### DIFF
--- a/PHPCI/Plugin/ApiGen.php
+++ b/PHPCI/Plugin/ApiGen.php
@@ -1,0 +1,60 @@
+<?php
+namespace PHPCI\Plugin;
+
+use PHPCI\Builder;
+use PHPCI\Model\Build;
+
+class ApiGen implements \PHPCI\Plugin
+{
+    /**
+     * PHPCI
+     * @var Builder
+     */
+    protected $phpci;
+
+    /**
+     * Build
+     * @var Build
+     */
+    protected $build;
+
+    /**
+     * Standard Constructor
+     *
+     * @param Builder $phpci
+     * @param Build   $build
+     * @param array   $options
+     */
+    public function __construct(Builder $phpci, Build $build, array $options = array())
+    {
+        // Basic
+        $this->phpci = $phpci;
+        $this->build = $build;
+    }
+
+    /**
+     * Returns PHPCI
+     *
+     * @return PHPCI
+     */
+    public function getPHPCI()
+    {
+        return $this->phpci;
+    }
+
+    /**
+     * Returns Build
+     *
+     * @return Build
+     */
+    public function getBuild()
+    {
+        return $this->build;
+    }
+
+    // Execution
+    public function execute()
+    {
+        return true;
+    }
+}

--- a/PHPCI/Plugin/ApiGen.php
+++ b/PHPCI/Plugin/ApiGen.php
@@ -4,6 +4,9 @@ namespace PHPCI\Plugin;
 use PHPCI\Builder;
 use PHPCI\Model\Build;
 
+/**
+ * PHPCI ApiGen Plugin
+ */
 class ApiGen implements \PHPCI\Plugin
 {
     /**
@@ -23,9 +26,8 @@ class ApiGen implements \PHPCI\Plugin
      *
      * @param Builder $phpci
      * @param Build   $build
-     * @param array   $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    public function __construct(Builder $phpci, Build $build)
     {
         // Basic
         $this->phpci = $phpci;
@@ -52,9 +54,35 @@ class ApiGen implements \PHPCI\Plugin
         return $this->build;
     }
 
-    // Execution
+    /**
+     * Plugin Execution
+     *
+     * @return boolean Result
+     */
     public function execute()
     {
-        return true;
+        $phpci      = $this->getPHPCI();
+        $executable = $phpci->findBinary('apigen');
+
+        if (!$executable) {
+            $phpci->logFailure('Could not find ApiGen executable.');
+            return false;
+        }
+
+        if (!is_readable($phpci->buildPath . '/apigen.neon')) {
+            $phpci->logFailure('Could not find ApiGen configuration file.');
+            return false;
+        }
+
+        // Push Path
+        $path = getcwd();
+        chdir($phpci->buildPath);
+
+        $result = $phpci->executeCommand($executable . ' generate');
+
+        // Pop Path
+        chdir($path);
+
+        return $result;
     }
 }

--- a/Tests/PHPCI/Plugin/ApiGenTest.php
+++ b/Tests/PHPCI/Plugin/ApiGenTest.php
@@ -5,6 +5,13 @@ use PHPCI\Plugin\ApiGen as ApiGenPlugin;
 
 class ApiGenTest extends \PHPUnit_Framework_TestCase
 {
+    protected $directory;
+
+    protected function tearDown()
+    {
+        $this->clearSource();
+    }
+
     protected function getPlugin(array $options = array())
     {
         $build = $this
@@ -13,11 +20,80 @@ class ApiGenTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $phpci = $this
-            ->getMockBUilder('PHPCI\Builder')
+            ->getMockBuilder('PHPCI\Builder')
+            ->setMethods(null)
             ->disableOriginalConstructor()
             ->getMock();
 
+        $directory = $this->buildSource();
+
+        $phpci->buildPath = $directory . '/container';
+
+        $executor = $this
+            ->getMockBuilder('PHPCI\Helper\UnixCommandExecutor')
+            ->setMethods(null)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $property = new \ReflectionProperty('PHPCI\Builder', 'commandExecutor');
+        $property->setAccessible(true);
+        $property->setValue($phpci, $executor);
+
+        $logger = $this
+            ->getMockBuilder('PHPCI\Logging\BuildLogger')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $property = new \ReflectionProperty('PHPCI\Builder', 'buildLogger');
+        $property->setAccessible(true);
+        $property->setValue($phpci, $logger);
+        $property = new \ReflectionProperty('PHPCI\Helper\BaseCommandExecutor', 'logger');
+        $property->setAccessible(true);
+        $property->setValue($executor, $logger);
+        $property = new \ReflectionProperty('PHPCI\Helper\BaseCommandExecutor', 'rootDir');
+        $property->setAccessible(true);
+        $property->setValue($executor, APPLICATION_PATH);
+
         return new ApiGenPlugin($phpci, $build, $options);
+    }
+
+    protected function buildTemp()
+    {
+        $directory = tempnam(APPLICATION_PATH . '/Tests/temp', 'source');
+        unlink($directory);
+        return $directory;
+    }
+
+    protected function buildSource()
+    {
+        $directory = $this->buildTemp();
+        mkdir($directory);
+        mkdir($directory . '/container');
+        file_put_contents($directory . '/container/apigen.neon', "source:\n    - src\n\ndestination: api\n");
+        mkdir($directory . '/container/src');
+        file_put_contents($directory . '/container/src/SomeClass.php', "<?php\nclass SomeClass\n{\n}");
+        $this->directory = $directory;
+        return $this->directory;
+    }
+
+    protected function clearSource()
+    {
+        if ($this->directory) {
+            $cleaner = function ($cleaner, $directory) {
+                $resource = opendir($directory);
+                while (($filename = readdir($resource)) !== false) {
+                    if ($filename != '.' && $filename != '..') {
+                        $filename = $directory . DIRECTORY_SEPARATOR . $filename;
+                        if (is_dir($filename)) {
+                            $cleaner($cleaner, $filename);
+                        } else {
+                            unlink($filename);
+                        }
+                    }
+                }
+                closedir($resource);
+                rmdir($directory);
+            };
+            $cleaner($cleaner, $this->directory);
+        }
     }
 
     public function testPlugin()
@@ -28,9 +104,20 @@ class ApiGenTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('PHPCI\Builder', $plugin->getPHPCI());
     }
 
-    public function testExecute()
+    public function testSuccess()
     {
         $plugin = $this->getPlugin();
+
         $this->assertTrue($plugin->execute());
+        $this->assertFileExists($plugin->getPHPCI()->buildPath . '/api/index.html');
+    }
+
+    public function testUnknownConfigurationFile()
+    {
+        $plugin = $this->getPlugin();
+        // Remove Configuration File
+        unlink($plugin->getPHPCI()->buildPath . '/apigen.neon');
+
+        $this->assertFalse($plugin->execute());
     }
 }

--- a/Tests/PHPCI/Plugin/ApiGenTest.php
+++ b/Tests/PHPCI/Plugin/ApiGenTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace PHPCI\Plugin\Tests;
+
+use PHPCI\Plugin\ApiGen as ApiGenPlugin;
+
+class ApiGenTest extends \PHPUnit_Framework_TestCase
+{
+    protected function getPlugin(array $options = array())
+    {
+        $build = $this
+            ->getMockBuilder('PHPCI\Model\Build')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $phpci = $this
+            ->getMockBUilder('PHPCI\Builder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return new ApiGenPlugin($phpci, $build, $options);
+    }
+
+    public function testPlugin()
+    {
+        $plugin = $this->getPlugin();
+        $this->assertInstanceOf('PHPCI\Plugin', $plugin);
+        $this->assertInstanceOf('PHPCI\Model\Build', $plugin->getBuild());
+        $this->assertInstanceOf('PHPCI\Builder', $plugin->getPHPCI());
+    }
+
+    public function testExecute()
+    {
+        $plugin = $this->getPlugin();
+        $this->assertTrue($plugin->execute());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "behat/behat": "Behat BDD Testing",
         "hipchat/hipchat-php": "Hipchat integration",
         "phptal/phptal": "PHPTAL templating engine",
-        "maknz/slack": "Slack integration"
+        "maknz/slack": "Slack integration",
+        "apigen/apigen": "ApiGen API generator"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4ae188c6be1c1388de6271a3b0e0475d",
+    "hash": "7a4191bf585d18b83f6247b44eb2b7dd",
     "packages": [
         {
             "name": "block8/b8framework",
@@ -97,16 +97,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.12.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
+                "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
-                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
+                "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
                 "shasum": ""
             },
             "require": {
@@ -123,6 +123,7 @@
                 "phpunit/phpunit": "~4.0",
                 "raven/raven": "~0.5",
                 "ruflin/elastica": "0.90.*",
+                "swiftmailer/swiftmailer": "~5.3",
                 "videlalvaro/php-amqplib": "~2.4"
             },
             "suggest": {
@@ -139,7 +140,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12.x-dev"
+                    "dev-master": "1.13.x-dev"
                 }
             },
             "autoload": {
@@ -165,19 +166,19 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2014-12-29 21:29:35"
+            "time": "2015-03-09 09:58:04"
         },
         {
             "name": "pimple/pimple",
             "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fabpot/Pimple.git",
+                "url": "https://github.com/silexphp/Pimple.git",
                 "reference": "2019c145fe393923f3441b23f29bbdfaa5c58c4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fabpot/Pimple/zipball/2019c145fe393923f3441b23f29bbdfaa5c58c4d",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/2019c145fe393923f3441b23f29bbdfaa5c58c4d",
                 "reference": "2019c145fe393923f3441b23f29bbdfaa5c58c4d",
                 "shasum": ""
             },
@@ -202,9 +203,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
@@ -317,16 +316,16 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.3.1",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "c5f963e7f9d6f6438fda4f22d5cc2db296ec621a"
+                "reference": "31454f258f10329ae7c48763eb898a75c39e0a9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/c5f963e7f9d6f6438fda4f22d5cc2db296ec621a",
-                "reference": "c5f963e7f9d6f6438fda4f22d5cc2db296ec621a",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/31454f258f10329ae7c48763eb898a75c39e0a9f",
+                "reference": "31454f258f10329ae7c48763eb898a75c39e0a9f",
                 "shasum": ""
             },
             "require": {
@@ -338,7 +337,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3-dev"
+                    "dev-master": "5.4-dev"
                 }
             },
             "autoload": {
@@ -365,7 +364,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2014-12-05 14:17:14"
+            "time": "2015-03-14 06:06:39"
         },
         {
             "name": "symfony/config",
@@ -677,16 +676,16 @@
         },
         {
             "name": "pdepend/pdepend",
-            "version": "2.0.4",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "1b0acf162da4f30237987e61e177a57f78e3d87e"
+                "reference": "a15ffcbfbcc4570d4a733ca7b76e9cac0a56c3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1b0acf162da4f30237987e61e177a57f78e3d87e",
-                "reference": "1b0acf162da4f30237987e61e177a57f78e3d87e",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/a15ffcbfbcc4570d4a733ca7b76e9cac0a56c3f4",
+                "reference": "a15ffcbfbcc4570d4a733ca7b76e9cac0a56c3f4",
                 "shasum": ""
             },
             "require": {
@@ -712,7 +711,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2014-12-04 12:38:39"
+            "time": "2015-03-02 08:06:43"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -765,24 +764,27 @@
         },
         {
             "name": "phploc/phploc",
-            "version": "2.0.6",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phploc.git",
-                "reference": "322ad07c112d5c6832abed4269d648cacff5959b"
+                "reference": "0e7ead01180d93536dec14da10d038a62d9f509d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phploc/zipball/322ad07c112d5c6832abed4269d648cacff5959b",
-                "reference": "322ad07c112d5c6832abed4269d648cacff5959b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phploc/zipball/0e7ead01180d93536dec14da10d038a62d9f509d",
+                "reference": "0e7ead01180d93536dec14da10d038a62d9f509d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=5.4",
                 "sebastian/finder-facade": "~1.1",
-                "sebastian/git": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/console": "~2.2"
+                "sebastian/git": "~2.0",
+                "sebastian/version": "~1.0.3",
+                "symfony/console": "~2.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4"
             },
             "bin": [
                 "phploc"
@@ -790,7 +792,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -811,20 +813,20 @@
             ],
             "description": "A tool for quickly measuring the size of a PHP project.",
             "homepage": "https://github.com/sebastianbergmann/phploc",
-            "time": "2014-06-25 08:11:02"
+            "time": "2015-03-10 16:49:43"
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "580e6ca75b472a844389ab8df7a0b412901d0d91"
+                "reference": "58c4b00f924d301e8c5281f40cfa9a66f3df9eee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/580e6ca75b472a844389ab8df7a0b412901d0d91",
-                "reference": "580e6ca75b472a844389ab8df7a0b412901d0d91",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/58c4b00f924d301e8c5281f40cfa9a66f3df9eee",
+                "reference": "58c4b00f924d301e8c5281f40cfa9a66f3df9eee",
                 "shasum": ""
             },
             "require": {
@@ -835,7 +837,8 @@
                 "symfony/filesystem": ">=2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "*"
+                "phpunit/phpunit": "*",
+                "squizlabs/php_codesniffer": "*"
             },
             "bin": [
                 "src/bin/phpmd"
@@ -872,7 +875,7 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2015-01-25 13:46:59"
+            "time": "2015-03-02 10:26:50"
         },
         {
             "name": "phpspec/prophecy",
@@ -1627,16 +1630,16 @@
         },
         {
             "name": "sebastian/git",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/git.git",
-                "reference": "a99fbc102e982c1404041ef3e4d431562b29bcba"
+                "reference": "572c35353fefcc8607d6fef0e362a9f3a5e84d96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/git/zipball/a99fbc102e982c1404041ef3e4d431562b29bcba",
-                "reference": "a99fbc102e982c1404041ef3e4d431562b29bcba",
+                "url": "https://api.github.com/repos/sebastianbergmann/git/zipball/572c35353fefcc8607d6fef0e362a9f3a5e84d96",
+                "reference": "572c35353fefcc8607d6fef0e362a9f3a5e84d96",
                 "shasum": ""
             },
             "require": {
@@ -1645,7 +1648,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1669,7 +1672,7 @@
             "keywords": [
                 "git"
             ],
-            "time": "2013-08-04 09:35:29"
+            "time": "2014-06-14 07:12:53"
         },
         {
             "name": "sebastian/global-state",
@@ -1812,20 +1815,21 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b301c98f19414d836fdaa678648745fcca5aeb4f"
+                "reference": "5046b0e01c416fc2b06df961d0673c85bcdc896c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b301c98f19414d836fdaa678648745fcca5aeb4f",
-                "reference": "b301c98f19414d836fdaa678648745fcca5aeb4f",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5046b0e01c416fc2b06df961d0673c85bcdc896c",
+                "reference": "5046b0e01c416fc2b06df961d0673c85bcdc896c",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
                 "php": ">=5.1.2"
             },
             "bin": [
@@ -1833,6 +1837,11 @@
                 "scripts/phpcbf"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "CodeSniffer.php",
@@ -1876,7 +1885,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2015-01-21 22:44:05"
+            "time": "2015-03-04 02:07:03"
         },
         {
             "name": "symfony/dependency-injection",
@@ -2030,6 +2039,7 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3.8",
         "ext-pdo": "*",


### PR DESCRIPTION
Olá a todos! :smiley:

# ApiGen Plugin `api_gen`

I develop a super simple ApiGen plugin according to #143. You'll only need to add an `apigen.neon` configuration in the root of your project.

More information in https://github.com/apigen/ApiGen.

## Notices

1. I don't know if my `composer.lock` change is right. Future problems with merging? Probably;
2. Plugin supports only `apigen >= 4.*`. Composer `suggest` option don't support versions;
3. Stage "success" and plugins without options cause PHP Fatal Error. 8ca0a04 and 86157cc. Fixed;
4. I called a `chdir` before and after binary execution;
5. I can't use vfs to create a project structure because `apigen` is called with `proc_open`; and
6. My PR will only pass in PHPCI if PR #749 55a2b79 is applied; thanks @corretge.

## Usage

Add to your `phpci.yml`:

```
success:
    api_gen:
```