### PR TITLE
Fix undefined variable '$config' in /Tests/bootstrap.php

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -31,8 +31,9 @@ if (!file_exists($configFile)) {
     }
 }
 
+$config = new b8\Config($conf);
+
 if (file_exists($configFile)) {
-    $config = new b8\Config($conf);
     $config->loadYaml($configFile);
 }
 


### PR DESCRIPTION
When no config-file was found, no instance of Config was created as well, resulting in:

PHP Notice:  Undefined variable: config in /Tests/bootstrap.php on line 41

This changes /Tests/bootstrap.php to always create an instance of b8\Config(), even if no file was found.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>