### PR TITLE
Fix/ssh keygen params

### DIFF
--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -46,12 +46,6 @@ abstract class BaseCommandExecutor implements CommandExecutor
     protected $rootDir;
 
     /**
-     * Current build path
-     * @var string
-     */
-    protected $buildPath;
-
-    /**
      * @param BuildLogger $logger
      * @param string      $rootDir
      * @param bool        $quiet
@@ -92,7 +86,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
         $pipes = array();
 
-        $process = proc_open($command, $descriptorSpec, $pipes, dirname($this->buildPath), null);
+        $process = proc_open($command, $descriptorSpec, $pipes, null, null);
 
         if (is_resource($process)) {
             fclose($pipes[0]);

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -46,6 +46,12 @@ abstract class BaseCommandExecutor implements CommandExecutor
     protected $rootDir;
 
     /**
+     * Current build path
+     * @var string
+     */
+    protected $buildPath;
+
+    /**
      * @param BuildLogger $logger
      * @param string      $rootDir
      * @param bool        $quiet
@@ -86,7 +92,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
         $pipes = array();
 
-        $process = proc_open($command, $descriptorSpec, $pipes, null, null);
+        $process = proc_open($command, $descriptorSpec, $pipes, dirname($this->buildPath), null);
 
         if (is_resource($process)) {
             fclose($pipes[0]);

--- a/PHPCI/Helper/SshKey.php
+++ b/PHPCI/Helper/SshKey.php
@@ -63,7 +63,7 @@ class SshKey
      */
     public function canGenerateKeys()
     {
-        $keygen = @shell_exec('ssh-keygen -h');
+        $keygen = @shell_exec('ssh-keygen --help');
         $canGenerateKeys = !empty($keygen);
 
         return $canGenerateKeys;


### PR DESCRIPTION
This fixes incorrect parameters used to check if ssh-keygen exists. These incorrect params cause ssh-keygen to be interactive and thus hang the PHP process indefinitely.