### PR TITLE
fixed settings handling for symlink creation in local build

### DIFF
--- a/PHPCI/Model/Build/LocalBuild.php
+++ b/PHPCI/Model/Build/LocalBuild.php
@@ -35,11 +35,13 @@ class LocalBuild extends Build
             return $this->handleConfig($builder, $buildPath) !== false;
         }
 
-        $buildSettings = $this->handleConfig($builder, $reference);
+        $configHandled = $this->handleConfig($builder, $reference);
 
-        if ($buildSettings === false) {
+        if ($configHandled === false) {
             return false;
         }
+
+        $buildSettings = $builder->getConfig('build_settings');
 
         if (isset($buildSettings['prefer_symlink']) && $buildSettings['prefer_symlink'] === true) {
             return $this->handleSymlink($builder, $reference, $buildPath);


### PR DESCRIPTION
Since the rewrite of the config handling, the local build was not able to create a symlink. This PR fixes that.