### PR TITLE
Escape commit message from XSS and broken markup.

### DIFF
--- a/PHPCI/Model/Base/BuildBase.php
+++ b/PHPCI/Model/Base/BuildBase.php
@@ -323,7 +323,7 @@ class BuildBase extends Model
     {
         $rtn    = $this->data['commit_message'];
 
-        return $rtn;
+        return htmlspecialchars($rtn);
     }
 
     /**


### PR DESCRIPTION
Commit message has potentially dangerous content like XSS, or markup broken when commit messages has html <tags>.

Maybe better is escape string before print in templates? Or before writing in database. I don't know a better way, it's just a quick fix.