### PR TITLE
Render the public key on the project edit page.

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -263,7 +263,7 @@ class ProjectController extends \PHPCI\Controller
             $view->type     = 'edit';
             $view->project  = $project;
             $view->form     = $form;
-            $view->key      = null;
+            $view->key      = $values['pubkey'];
 
             return $view->render();
         }


### PR DESCRIPTION
When you create a new project, a box appears at the right hand side to show you the public deployment key you need to add to your repository to allow PHPCI to pull down the code.

Once a project is created though, there's no way to access the key - it's not shown on the project form any more. The attached patch sorted it for me, but not sure if there are other impacts since this was specifically set to null previously?