### PR TITLE
Move legends to below chart to avoid word wrapping issues

### DIFF
--- a/public/assets/js/build-plugins/loc.js
+++ b/public/assets/js/build-plugins/loc.js
@@ -55,7 +55,8 @@ var locPlugin = ActiveBuild.UiPlugin.extend({
             hAxis: {title: Lang.get('builds')},
             vAxis: {title: Lang.get('lines')},
             backgroundColor: { fill: 'transparent' },
-            height: 275
+            height: 275,
+            legend: {position: 'bottom'}
         };
 
         $('#build-lines-chart').show();

--- a/public/assets/js/build-plugins/warnings.js
+++ b/public/assets/js/build-plugins/warnings.js
@@ -97,7 +97,8 @@ var warningsPlugin = ActiveBuild.UiPlugin.extend({
             vAxis: {title: Lang.get('issues'), logScale:true},
             backgroundColor: { fill: 'transparent' },
             height: 275,
-            pointSize: 3
+            pointSize: 3,
+            legend: {position: 'bottom'}
         };
 
         $('#build-warnings-chart').show();


### PR DESCRIPTION
The standard Lines of Code, and Quality Trend charts have the legend to the write. On my display at least, this causes word wrapping issues that render the legends pretty much useless.

This change moves the legends to below the chart which improves things considerably. 

Before the change:
https://www.dropbox.com/s/55yrz602a3h1uba/Screenshot%202015-02-01%2015.20.07.png?dl=0

After the change:
https://www.dropbox.com/s/1qiw8nakpnj2c48/Screenshot%202015-02-01%2015.21.58.png?dl=0



