### PR TITLE
Fixes and improvements to german translation

### DIFF
--- a/PHPCI/Languages/lang.de.php
+++ b/PHPCI/Languages/lang.de.php
@@ -56,7 +56,7 @@ PHPCI',
     // Sidebar
     'hello_name' => 'Hallo, %s',
     'dashboard' => 'Dashboard',
-    'admin_options' => 'Administraion',
+    'admin_options' => 'Administration',
     'add_project' => 'Projekt hinzufügen',
     'settings' => 'Einstellungen',
     'manage_users' => 'Benutzereinstellungen',

--- a/PHPCI/Languages/lang.de.php
+++ b/PHPCI/Languages/lang.de.php
@@ -13,7 +13,7 @@ $strings = array(
 
     // Log in:
     'log_in_to_phpci' => 'In PHPCI einloggen',
-    'login_error' => 'Fehlerhafte Emailadresse oder fehlerhaftes Passowrt',
+    'login_error' => 'Fehlerhafte Emailadresse oder fehlerhaftes Passwort',
     'forgotten_password_link' => 'Passwort vergessen?',
     'reset_emailed' => 'Wir haben Ihnen einen Link geschickt, um Ihr Passwort zurückzusetzen',
     'reset_header' => '<strong>Keine Panik!</strong><br>Geben Sie einfach unten Ihre Emailadresse an

--- a/PHPCI/Languages/lang.de.php
+++ b/PHPCI/Languages/lang.de.php
@@ -62,7 +62,7 @@ PHPCI',
     'manage_users' => 'Benutzereinstellungen',
     'plugins' => 'Plugins',
     'view' => 'Ansehen',
-    'build_now' => 'Aktueller Build',
+    'build_now' => 'Jetzt bauen',
     'edit_project' => 'Projekt bearbeiten',
     'delete_project' => 'Projekt löschen',
 


### PR DESCRIPTION
Fixes 2 typos.

Rephrases the "build_now" from "Aktueller Build"  to "Jetzt bauen"

The old variant "Akueller Build" is not correct since it reads like "Recent build" while this button actually triggers a build. 

"Jetzt bauen" fits way better and is what e.g. the jenkins "build now" button is translated to ;).
