### PR TITLE
#781 Allow to modify PHPCI configuration without modify versioned code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ PHPCI/Model/Migration.php
 PHPCI/Model/Base/MigrationBase.php
 PHPCI/Store/MigrationStore.php
 PHPCI/Store/Base/MigrationStoreBase.php
+local_vars.php

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -62,6 +62,17 @@ if (file_exists($configFile)) {
     $config->loadYaml($configFile);
 }
 
+/**
+ * Allow to modify PHPCI configuration without modify versioned code.
+ * Dameons should be killed to apply changes in the file.
+ *
+ * @ticket 781
+ */
+$localVarsFile = dirname(__FILE__) . '/local_vars.php';
+if (is_readable($localVarsFile)) {
+    require_once $localVarsFile;
+}
+
 require_once(dirname(__FILE__) . '/vars.php');
 
 \PHPCI\Helper\Lang::init($config);


### PR DESCRIPTION
Try to load unversioned file local_vars.php before to set the configuration constants for the project.