### PR TITLE
Make SSH key generation more robust.

### DIFF
--- a/PHPCI/Helper/SshKey.php
+++ b/PHPCI/Helper/SshKey.php
@@ -39,33 +39,22 @@ class SshKey
 
         $return = array('private_key' => '', 'public_key' => '');
 
-        if ($this->canGenerateKeys()) {
-            shell_exec('ssh-keygen -q -t rsa -b 2048 -f '.$keyFile.' -N "" -C "deploy@phpci"');
+        $output = @shell_exec('ssh-keygen -t rsa -b 2048 -f '.$keyFile.' -N "" -C "deploy@phpci"');
 
-            $pub = file_get_contents($keyFile . '.pub');
-            $prv = file_get_contents($keyFile);
+        if (!empty($output)) {
+	        $pub = file_get_contents($keyFile . '.pub');
+	        $prv = file_get_contents($keyFile);
 
-            if (!empty($pub)) {
-                $return['public_key'] = $pub;
-            }
+	        if (!empty($pub)) {
+	            $return['public_key'] = $pub;
+	        }
 
-            if (!empty($prv)) {
-                $return['private_key'] = $prv;
-            }
+	        if (!empty($prv)) {
+	            $return['private_key'] = $prv;
+	        }
         }
 
         return $return;
     }
 
-    /**
-     * Checks whether or not we can generate keys, by quietly test running ssh-keygen.
-     * @return bool
-     */
-    public function canGenerateKeys()
-    {
-        $keygen = @shell_exec('ssh-keygen --help');
-        $canGenerateKeys = !empty($keygen);
-
-        return $canGenerateKeys;
-    }
 }

--- a/PHPCI/Helper/SshKey.php
+++ b/PHPCI/Helper/SshKey.php
@@ -56,5 +56,4 @@ class SshKey
 
         return $return;
     }
-
 }

--- a/PHPCI/Helper/SshKey.php
+++ b/PHPCI/Helper/SshKey.php
@@ -42,16 +42,16 @@ class SshKey
         $output = @shell_exec('ssh-keygen -t rsa -b 2048 -f '.$keyFile.' -N "" -C "deploy@phpci"');
 
         if (!empty($output)) {
-	        $pub = file_get_contents($keyFile . '.pub');
-	        $prv = file_get_contents($keyFile);
+            $pub = file_get_contents($keyFile . '.pub');
+            $prv = file_get_contents($keyFile);
 
-	        if (!empty($pub)) {
-	            $return['public_key'] = $pub;
-	        }
+            if (!empty($pub)) {
+                $return['public_key'] = $pub;
+            }
 
-	        if (!empty($prv)) {
-	            $return['private_key'] = $prv;
-	        }
+            if (!empty($prv)) {
+                $return['private_key'] = $prv;
+            }
         }
 
         return $return;


### PR DESCRIPTION
Do not try and predict whether we will be able to create a key. Instead try and create one and capture failure if it happens. Hopefully fixes #800.

We now call ssh-keygen without "-q", and capture the output. If ssh-keygen fails then shell_exec should return NULL, so the presence of output implies success.

It'd be good to get testing on multiple setups for this. 

For reference I can confirm it works on MacOS Yosemite.