### PR TITLE
Fix username style in user panel block.

### DIFF
--- a/PHPCI/View/layout.phtml
+++ b/PHPCI/View/layout.phtml
@@ -134,7 +134,7 @@
                 <div class="pull-left image">
                     <img src="https://www.gravatar.com/avatar/<?php print md5($this->User()->getEmail()); ?>?d=mm" class="img-circle" alt="<?php print $this->User()->getName(); ?>" />
                 </div>
-                <div class="pull-left info">
+                <div class="info">
                     <p><?php Lang::out('hello_name', $this->User()->getName()); ?></p>
                 </div>
             </div>

--- a/public/assets/css/AdminLTE-custom.css
+++ b/public/assets/css/AdminLTE-custom.css
@@ -75,3 +75,13 @@
     margin-top: 19px;
     font-size: 11px;
 }
+
+.user-panel > .image {
+    padding-right: 15px;
+}
+
+.user-panel > .info {
+    padding: 0;
+    font-size: inherit;
+    line-height: inherit;
+}


### PR DESCRIPTION
My user name is to long and jumps to the next line.
Before:
![before](https://cloud.githubusercontent.com/assets/1087411/6345398/62e72102-bc0e-11e4-9307-3951f078cb59.png)
After:
![after](https://cloud.githubusercontent.com/assets/1087411/6345402/6592c910-bc0e-11e4-87c4-013f736f6219.png)

