### PR TITLE
Fix archive link.

### DIFF
--- a/PHPCI/View/layout.phtml
+++ b/PHPCI/View/layout.phtml
@@ -137,7 +137,7 @@
 
             <!-- sidebar menu: : style can be found in sidebar.less -->
             <ul class="sidebar-menu">
-                <li class="active">
+                <li<?php print (array_key_exists('archived', $_GET) ? '' : ' class="active"'); ?>>
                     <a href="<?php print PHPCI_URL; ?>">
                         <i class="fa fa-dashboard"></i> <span><?php Lang::out('dashboard'); ?></span>
                     </a>
@@ -237,8 +237,8 @@
                     </li>
                 <?php endif; ?>
 
-                <li class="archive">
-                    <a href="<?php print PHPCI_URL; ?>?archived">
+                <li class="archive<?php print (array_key_exists('archived', $_GET) ? ' active' : ''); ?>">
+                    <a href="<?php print PHPCI_URL . (array_key_exists('archived', $_GET) ? '' : '?archived'); ?>">
                         <i class="fa fa-archive"></i> <span><?php Lang::out('archived'); ?></span>
                     </a>
                 </li>


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: front-end
Link to Bug: #816

Description of change: added check if url containt `archived` parameter

Description of solution: set archive link to frontpage if we already on archive page and add class active to link.