### PR TITLE
Added a variable to configure the build root.

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -287,7 +287,7 @@ class Builder implements LoggerAwareInterface
      */
     protected function setupBuild()
     {
-        $this->buildPath = PHPCI_DIR . 'PHPCI/build/' . $this->build->getId() . '/';
+        $this->buildPath = PHPCI_BUILD_ROOT_DIR . $this->build->getId() . '/';
         $this->build->currentBuildPath = $this->buildPath;
 
         $this->interpolator->setupInterpolationVars(

--- a/PHPCI/Command/RunCommand.php
+++ b/PHPCI/Command/RunCommand.php
@@ -178,7 +178,7 @@ class RunCommand extends Command
 
     protected function removeBuildDirectory($build)
     {
-        $buildPath = PHPCI_DIR . 'PHPCI/build/' . $build->getId() . '/';
+        $buildPath = PHPCI_BUILD_ROOT_DIR . $build->getId() . '/';
 
         if (is_dir($buildPath)) {
             $cmd = 'rm -Rf "%s"';

--- a/PHPCI/Command/RunCommand.php
+++ b/PHPCI/Command/RunCommand.php
@@ -166,7 +166,7 @@ class RunCommand extends Command
                 $build->setStatus(Build::STATUS_FAILED);
                 $build->setFinished(new \DateTime());
                 $store->save($build);
-                $this->removeBuildDirectory($build);
+                $build->removeBuildDirectory();
                 continue;
             }
 
@@ -174,20 +174,5 @@ class RunCommand extends Command
         }
 
         return $rtn;
-    }
-
-    protected function removeBuildDirectory($build)
-    {
-        $buildPath = PHPCI_BUILD_ROOT_DIR . $build->getId() . '/';
-
-        if (is_dir($buildPath)) {
-            $cmd = 'rm -Rf "%s"';
-
-            if (IS_WIN) {
-                $cmd = 'rmdir /S /Q "%s"';
-            }
-
-            shell_exec($cmd);
-        }
     }
 }

--- a/PHPCI/Model/Build.php
+++ b/PHPCI/Model/Build.php
@@ -217,4 +217,28 @@ class Build extends BuildBase
     {
         return array($builder, $file, $line, $message);
     }
+
+    /**
+     * Return the path to run this build into.
+     *
+     * @return string
+     */
+    public function getBuildPath()
+    {
+        return PHPCI_BUILD_ROOT_DIR . $this->getId();
+    }
+
+    /**
+     * Removes the build directory.
+     */
+    public function removeBuildDirectory()
+    {
+        $buildPath = $this->getBuildPath();
+
+        if (!is_dir($buildPath)) {
+            return;
+        }
+
+        exec(sprintf(IS_WIN ? 'rmdir /S /Q "%s"' : 'rm -Rf "%s"', $buildPath));
+    }
 }

--- a/PHPCI/Service/BuildService.php
+++ b/PHPCI/Service/BuildService.php
@@ -112,6 +112,7 @@ class BuildService
      */
     public function deleteBuild(Build $build)
     {
+        $build->removeBuildDirectory();
         return $this->buildStore->delete($build);
     }
 }

--- a/vars.php
+++ b/vars.php
@@ -16,6 +16,11 @@ if (!defined('PHPCI_BIN_DIR')) {
     define('PHPCI_BIN_DIR', PHPCI_DIR . 'vendor/bin/');
 }
 
+// Define PHPCI_BUILD_ROOT_DIR
+if (!defined('PHPCI_BUILD_ROOT_DIR')) {
+    define('PHPCI_BUILD_ROOT_DIR', PHPCI_DIR . 'PHPCI/build/');
+}
+
 // Should PHPCI run the Shell plugin?
 if (!defined('ENABLE_SHELL_PLUGIN')) {
     define('ENABLE_SHELL_PLUGIN', false);


### PR DESCRIPTION
This variable allows to change where the builds are done, e.g. builds while be created in PHPCI_BUILD_ROOT_DIR/%BUILD%/. To avoid breaking existing installation, it defaults to PHPCI_DIR.'PHPCI/build/'.

(It bothered me that the builds were done inside PHPCI's sources.)