### PR TITLE
Use persistent repository mirrors to speed up git cloning.

### DIFF
--- a/PHPCI/Model/Build/RemoteGitBuild.php
+++ b/PHPCI/Model/Build/RemoteGitBuild.php
@@ -82,10 +82,10 @@ class RemoteGitBuild extends Build
         $mirrorPath = $this->getMirrorPath();
         if ($mirrorPath && is_dir($mirrorPath)) {
             $cmd = sprintf(
-                IS_WIN ? 'rmdir /S /Q "%s"' : 'rm -rfv "%s"',
+                IS_WIN ? 'rmdir /S /Q "%s"' : 'rm -rf "%s"',
                 $mirrorPath
             );
-            var_dump([$cmd, shell_exec($cmd)]);
+            exec($cmd);
         }
     }
 

--- a/PHPCI/Model/Build/RemoteGitBuild.php
+++ b/PHPCI/Model/Build/RemoteGitBuild.php
@@ -33,76 +33,77 @@ class RemoteGitBuild extends Build
     */
     public function createWorkingCopy(Builder $builder, $buildPath)
     {
-        $key = trim($this->getProject()->getSshPrivateKey());
-
-        if (!empty($key)) {
-            $success = $this->cloneBySsh($builder, $buildPath);
-        } else {
-            $success = $this->cloneByHttp($builder, $buildPath);
-        }
-
-        if (!$success) {
-            $builder->logFailure('Failed to clone remote git repository.');
-            return false;
-        }
-
-        return $this->handleConfig($builder, $buildPath);
-    }
-
-    /**
-    * Use an HTTP-based git clone.
-    */
-    protected function cloneByHttp(Builder $builder, $cloneTo)
-    {
-        $cmd = 'git clone ';
+        $cloneArgs = '--branch "'.$this->getBranch().'"';
 
         $depth = $builder->getConfig('clone_depth');
-
         if (!is_null($depth)) {
-            $cmd .= ' --depth ' . intval($depth) . ' ';
+            $cloneArgs .= ' --depth ' . intval($depth);
         }
 
-        $cmd .= ' -b %s %s "%s"';
-        $success = $builder->executeCommand($cmd, $this->getBranch(), $this->getCloneUrl(), $cloneTo);
+        $success = true;
 
-        if ($success) {
-            $success = $this->postCloneSetup($builder, $cloneTo);
+        // Create and/or update a mirror repository if phpci.git.mirrors if defined
+        $mirrorRootPath = $builder->getSystemConfig('phpci.git.mirrors');
+        if (null !== $mirrorRootPath) {
+            $mirrorPath = $mirrorRootPath.'/'.preg_replace('/[^a-zA-Z_-]/', '_', $this->getCloneUrl());
+            $success = $this->manageMirror($builder, $mirrorPath);
+            $cloneArgs .= ' --reference="'.$mirrorPath.'"';
         }
 
-        return $success;
+        if ($success
+            && $this->cloneTo($builder, $buildPath, $cloneArgs)
+            && $this->postCloneSetup($builder, $buildPath)
+        ) {
+            return $this->handleConfig($builder, $buildPath);
+        }
+
+        $builder->logFailure('Failed to clone remote git repository.');
+        return false;
     }
 
-    /**
-    * Use an SSH-based git clone.
-    */
-    protected function cloneBySsh(Builder $builder, $cloneTo)
+    /** Create and/or update a persistent mirror of the remote repository.
+     *
+     * @param Builder $builder
+     * @param string $mirrorPath
+     *
+     * @return bool
+     */
+    protected function manageMirror(Builder $builder, $mirrorPath)
     {
-        $keyFile = $this->writeSshKey($cloneTo);
+        if (!is_dir($mirrorPath)) {
+            // First run: create the mirror
+            return $this->cloneTo($builder, $mirrorPath, '--mirror');
+        }
 
+        // Update the mirror
+        return $builder->executeCommand('git --git-dir="%s" --bare remote update --prune', $mirrorPath);
+    }
+
+    /** Clone a remote repository into a local directory.
+     *
+     * @param Builder $builder
+     * @param string $cloneTo
+     * @param string $args Additional arguments.
+     *
+     * @return bool
+     */
+    protected function cloneTo(Builder $builder, $cloneTo, $args)
+    {
+        if (preg_match('/^((f|ht)tps?|git|file):/', $this->getCloneUrl())) {
+            // Not SSH URL
+            return $builder->executeCommand('git clone %s "%s" "%s"', $args, $this->getCloneUrl(), $cloneTo);
+        }
+
+        $cmd = 'git clone %s "%s" "%s"';
+
+        // Create the keyfile and a SSH wrapper
+        $keyFile = $this->writeSshKey($cloneTo);
         if (!IS_WIN) {
             $gitSshWrapper = $this->writeSshWrapper($cloneTo, $keyFile);
-        }
-
-        // Do the git clone:
-        $cmd = 'git clone ';
-
-        $depth = $builder->getConfig('clone_depth');
-
-        if (!is_null($depth)) {
-            $cmd .= ' --depth ' . intval($depth) . ' ';
-        }
-
-        $cmd .= ' -b %s %s "%s"';
-
-        if (!IS_WIN) {
             $cmd = 'export GIT_SSH="'.$gitSshWrapper.'" && ' . $cmd;
         }
 
-        $success = $builder->executeCommand($cmd, $this->getBranch(), $this->getCloneUrl(), $cloneTo);
-
-        if ($success) {
-            $success = $this->postCloneSetup($builder, $cloneTo);
-        }
+        $success = $builder->executeCommand($cmd, $args, $this->getCloneUrl(), $cloneTo);
 
         // Remove the key file and git wrapper:
         unlink($keyFile);

--- a/PHPCI/Model/Project.php
+++ b/PHPCI/Model/Project.php
@@ -139,7 +139,7 @@ class Project extends ProjectBase
     public function cleanup()
     {
         $build = $this->getLatestBuild();
-        if (!$build) {
+        if ($build instanceof Build) {
             $build = BuildFactory::getBuild($build);
             if ($build instanceof Build\RemoteGitBuild) {
                 $build->removeMirror();

--- a/PHPCI/Model/Project.php
+++ b/PHPCI/Model/Project.php
@@ -9,6 +9,7 @@
 
 namespace PHPCI\Model;
 
+use PHPCI\BuildFactory;
 use PHPCI\Model\Base\ProjectBase;
 use PHPCI\Model\Build;
 use b8\Store;
@@ -130,5 +131,19 @@ class Project extends ProjectBase
         }
 
         return $icon;
+    }
+
+    /**
+     * Clean up build leftovers when the project is destroyed or archived.
+     */
+    public function cleanup()
+    {
+        $build = $this->getLatestBuild();
+        if (!$build) {
+            $build = BuildFactory::getBuild($build);
+            if ($build instanceof Build\RemoteGitBuild) {
+                $build->removeMirror();
+            }
+        }
     }
 }

--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -99,7 +99,7 @@ class ProjectService
         $rtn = $this->projectStore->save($project);
 
         // Cleanup if archived or the reference changed
-        if(isset($modified['archived']) || isset($modified['reference'])) {
+        if (isset($modified['archived']) || isset($modified['reference'])) {
             $project->cleanup();
         }
 

--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -92,8 +92,18 @@ class ProjectService
         // Allow certain project types to set access information:
         $this->processAccessInformation($project);
 
+        // Get modified attributes
+        $modified = $project->getModified();
+
         // Save and return the project:
-        return $this->projectStore->save($project);
+        $rtn = $this->projectStore->save($project);
+
+        // Cleanup if archived or the reference changed
+        if(isset($modified['archived']) || isset($modified['reference'])) {
+            $project->cleanup();
+        }
+
+        return $rtn;
     }
 
     /**
@@ -103,7 +113,9 @@ class ProjectService
      */
     public function deleteProject(Project $project)
     {
-        return $this->projectStore->delete($project);
+        $rtn = $this->projectStore->delete($project);
+        $project->cleanup();
+        return $rtn;
     }
 
     /**


### PR DESCRIPTION
This is basically an implementation for https://github.com/Block8/PHPCI/issues/302.

Once the administrator sets up a directory and indicates it in config.yml, PHPCI creates mirrors of the remote repositories and reuses them in subsequence builds.

E.g. given, the configuration:

```yml
phpci:
  git:
    mirrors: /var/cache/phpci
```

When cloning https://github.com/Block8/PHPCI.git, for the first time, PHPCI will do this:

```bash
git clone --mirror "https://github.com/Block8/PHPCI.git" "/var/cache/phpci/https___github_com_Block8_PHPCI_git"
git clone --reference="/var/cache/phpci/https___github_com_Block8_PHPCI_git" --branch="master" "https://github.com/Block8/PHPCI.git" "/phpci/PHPCI/build/85"
```

On subsequence build,s it will do this:
```bash
git --git-dir="/var/cache/phpci/https___github_com_Block8_PHPCI_git" remote update --prune 
git clone --reference="/var/cache/phpci/https___github_com_Block8_PHPCI_git" --branch="master" "https://github.com/Block8/PHPCI.git" "/phpci/PHPCI/build/85"
```
