### PR TITLE
Env plugin: add variables to the interpolator.

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -402,6 +402,14 @@ class Builder implements LoggerAwareInterface
             'Swift_Mailer'
         );
 
+        $pluginFactory->registerResource(
+            function () use ($self) {
+                return $self->interpolator;
+            },
+            null,
+            'PHPCI\Helper\BuildInterpolator'
+        );
+
         return $pluginFactory;
     }
 }

--- a/PHPCI/Helper/BuildInterpolator.php
+++ b/PHPCI/Helper/BuildInterpolator.php
@@ -52,7 +52,7 @@ class BuildInterpolator
         $this->interpolation_vars['%PHPCI%'] = 1;
         putenv('PHPCI=1');
 
-        foreach($vars as $name => $value) {
+        foreach ($vars as $name => $value) {
             $this->interpolation_vars['%' . $name . '%'] = $value;
             $this->interpolation_vars['%PHPCI_' . $name . '%'] = $value;
             putenv(sprintf('PHPCI_%s=%s', $name, $value));

--- a/PHPCI/Helper/BuildInterpolator.php
+++ b/PHPCI/Helper/BuildInterpolator.php
@@ -27,53 +27,44 @@ class BuildInterpolator
 
     /**
      * Sets the variables that will be used for interpolation.
+     *
      * @param Build $build
      * @param string $buildPath
      * @param string $phpCiUrl
      */
     public function setupInterpolationVars(Build $build, $buildPath, $phpCiUrl)
     {
-        $this->interpolation_vars = array();
-        $this->interpolation_vars['%PHPCI%'] = 1;
-        $this->interpolation_vars['%COMMIT%'] = $build->getCommitId();
-        $this->interpolation_vars['%SHORT_COMMIT%'] = substr($build->getCommitId(), 0, 7);
-        $this->interpolation_vars['%COMMIT_EMAIL%'] = $build->getCommitterEmail();
-        $this->interpolation_vars['%COMMIT_URI%'] = $build->getCommitLink();
-        $this->interpolation_vars['%BRANCH%'] = $build->getBranch();
-        $this->interpolation_vars['%BRANCH_URI%'] = $build->getBranchLink();
-        $this->interpolation_vars['%PROJECT%'] = $build->getProjectId();
-        $this->interpolation_vars['%BUILD%'] = $build->getId();
-        $this->interpolation_vars['%PROJECT_TITLE%'] = $build->getProjectTitle();
-        $this->interpolation_vars['%PROJECT_URI%'] = $phpCiUrl . "project/view/" . $build->getProjectId();
-        $this->interpolation_vars['%BUILD_PATH%'] = $buildPath;
-        $this->interpolation_vars['%BUILD_URI%'] = $phpCiUrl . "build/view/" . $build->getId();
-        $this->interpolation_vars['%PHPCI_COMMIT%'] = $this->interpolation_vars['%COMMIT%'];
-        $this->interpolation_vars['%PHPCI_SHORT_COMMIT%'] = $this->interpolation_vars['%SHORT_COMMIT%'];
-        $this->interpolation_vars['%PHPCI_COMMIT_EMAIL%'] = $this->interpolation_vars['%COMMIT_EMAIL%'];
-        $this->interpolation_vars['%PHPCI_COMMIT_URI%'] = $this->interpolation_vars['%COMMIT_URI%'];
-        $this->interpolation_vars['%PHPCI_PROJECT%'] = $this->interpolation_vars['%PROJECT%'];
-        $this->interpolation_vars['%PHPCI_BUILD%'] = $this->interpolation_vars['%BUILD%'];
-        $this->interpolation_vars['%PHPCI_PROJECT_TITLE%'] = $this->interpolation_vars['%PROJECT_TITLE%'];
-        $this->interpolation_vars['%PHPCI_PROJECT_URI%'] = $this->interpolation_vars['%PROJECT_URI%'];
-        $this->interpolation_vars['%PHPCI_BUILD_PATH%'] = $this->interpolation_vars['%BUILD_PATH%'];
-        $this->interpolation_vars['%PHPCI_BUILD_URI%'] = $this->interpolation_vars['%BUILD_URI%'];
+        $vars = array(
+            'COMMIT'        => $build->getCommitId(),
+            'SHORT_COMMIT'  => substr($build->getCommitId(), 0, 7),
+            'COMMIT_EMAIL'  => $build->getCommitterEmail(),
+            'COMMIT_URI'    => $build->getCommitLink(),
+            'BRANCH'        => $build->getBranch(),
+            'BRANCH_URI'    => $build->getBranchLink(),
+            'PROJECT'       => $build->getProjectId(),
+            'BUILD'         => $build->getId(),
+            'PROJECT_TITLE' => $build->getProjectTitle(),
+            'PROJECT_URI'   => $phpCiUrl . "project/view/" . $build->getProjectId(),
+            'BUILD_PATH'    => $buildPath,
+            'BUILD_URI'     => $phpCiUrl . "build/view/" . $build->getId()
+        );
 
+        $this->interpolation_vars['%PHPCI%'] = 1;
         putenv('PHPCI=1');
-        putenv('PHPCI_COMMIT=' . $this->interpolation_vars['%COMMIT%']);
-        putenv('PHPCI_SHORT_COMMIT=' . $this->interpolation_vars['%SHORT_COMMIT%']);
-        putenv('PHPCI_COMMIT_EMAIL=' . $this->interpolation_vars['%COMMIT_EMAIL%']);
-        putenv('PHPCI_COMMIT_URI=' . $this->interpolation_vars['%COMMIT_URI%']);
-        putenv('PHPCI_PROJECT=' . $this->interpolation_vars['%PROJECT%']);
-        putenv('PHPCI_BUILD=' . $this->interpolation_vars['%BUILD%']);
-        putenv('PHPCI_PROJECT_TITLE=' . $this->interpolation_vars['%PROJECT_TITLE%']);
-        putenv('PHPCI_BUILD_PATH=' . $this->interpolation_vars['%BUILD_PATH%']);
-        putenv('PHPCI_BUILD_URI=' . $this->interpolation_vars['%BUILD_URI%']);
+
+        foreach($vars as $name => $value) {
+            $this->interpolation_vars['%' . $name . '%'] = $value;
+            $this->interpolation_vars['%PHPCI_' . $name . '%'] = $value;
+            putenv(sprintf('PHPCI_%s=%s', $name, $value));
+        }
     }
 
     /**
      * Replace every occurrence of the interpolation vars in the given string
      * Example: "This is build %PHPCI_BUILD%" => "This is build 182"
+     *
      * @param string $input
+     *
      * @return string
      */
     public function interpolate($input)

--- a/PHPCI/Helper/BuildInterpolator.php
+++ b/PHPCI/Helper/BuildInterpolator.php
@@ -73,4 +73,15 @@ class BuildInterpolator
         $values = array_values($this->interpolation_vars);
         return str_replace($keys, $values, $input);
     }
+
+    /**
+     * Set an interpolation variable.
+     *
+     * @param string $name The name of the variable to set, without the '%'.
+     * @param string $value The value to assign.
+     */
+    public function setInterpolationVar($name, $value)
+    {
+        $this->interpolation_vars['%' . $name . '%'] = (string)$value;
+    }
 }

--- a/PHPCI/Plugin/Env.php
+++ b/PHPCI/Plugin/Env.php
@@ -50,7 +50,6 @@ class Env implements \PHPCI\Plugin
     {
         $success = true;
         foreach ($this->env_vars as $key => $value) {
-
             if (is_numeric($key)) {
                 // This allows the developer to specify env vars like " - FOO=bar" or " - FOO: bar"
                 if (is_array($value)) {

--- a/PHPCI/Plugin/Env.php
+++ b/PHPCI/Plugin/Env.php
@@ -10,6 +10,7 @@
 namespace PHPCI\Plugin;
 
 use PHPCI\Builder;
+use PHPCI\Helper\BuildInterpolator;
 use PHPCI\Helper\Lang;
 use PHPCI\Model\Build;
 
@@ -24,17 +25,21 @@ class Env implements \PHPCI\Plugin
     protected $phpci;
     protected $build;
     protected $env_vars;
+    protected $interpolator;
 
     /**
      * Set up the plugin, configure options, etc.
+     *
      * @param Builder $phpci
      * @param Build $build
+     * @param BuildInterpolator $interpolator
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    public function __construct(Builder $phpci, Build $build, BuildInterpolator $interpolator, array $options = array())
     {
         $this->phpci = $phpci;
         $this->build = $build;
+        $this->interpolator = $interpolator;
         $this->env_vars = $options;
     }
 
@@ -45,15 +50,27 @@ class Env implements \PHPCI\Plugin
     {
         $success = true;
         foreach ($this->env_vars as $key => $value) {
+
             if (is_numeric($key)) {
                 // This allows the developer to specify env vars like " - FOO=bar" or " - FOO: bar"
-                $env_var = is_array($value)? key($value).'='.current($value): $value;
+                if (is_array($value)) {
+                    $env_name = key($value);
+                    $env_value = current($value);
+                } else {
+                    list($env_name, $env_value) = explode('=', $value, 2);
+                }
             } else {
                 // This allows the standard syntax: "FOO: bar"
-                $env_var = "$key=$value";
+                $env_name = $key;
+                $env_value = $value;
             }
-            
-            if (!putenv($this->phpci->interpolate($env_var))) {
+
+            $interpolated_name = $this->interpolator->interpolate($env_name);
+            $interpolated_value = $this->interpolator->interpolate($env_value);
+
+            if (putenv($interpolated_name . "=" . $interpolated_value)) {
+                $this->interpolator->setInterpolationVar($interpolated_name, $interpolated_value);
+            } else {
                 $success = false;
                 $this->phpci->logFailure(Lang::get('unable_to_set_env'));
             }

--- a/Tests/PHPCI/Helper/BuildInterpolatorTest.php
+++ b/Tests/PHPCI/Helper/BuildInterpolatorTest.php
@@ -45,5 +45,16 @@ class BuildInterpolatorTest extends ProphecyTestCase
 
         $this->assertEquals($expectedOutput, $actualOutput);
     }
+
+    public function testInterpolate_setInterpolationVar()
+    {
+        $string = "Hello %FOO%";
+        $expectedOutput = "Hello BAR";
+
+        $this->testedInterpolator->setInterpolationVar('FOO', 'BAR');
+
+        $actualOutput = $this->testedInterpolator->interpolate($string);
+
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
 }
- 

--- a/Tests/PHPCI/Plugin/EnvTest.php
+++ b/Tests/PHPCI/Plugin/EnvTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * PHPCI - Continuous Integration for PHP
+ *
+ * @copyright    Copyright 2013, Block 8 Limited.
+ * @license        https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ * @link            http://www.phptesting.org/
+ */
+
+namespace PHPCI\Plugin\Tests;
+
+use PHPCI\Plugin\Env as EnvPlugin;
+
+/**
+ * Unit test for the PHPUnit plugin.
+ * @author adirelle@gmail.cmo
+ */
+class EnvTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EnvPlugin
+     */
+    protected $testedEnvPlugin;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockBuild;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockBuilder;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockInterpolator;
+
+    /**
+     * Environment array to be used by the putenv() mock.
+     *
+     * @var array
+     */
+    public static $env;
+
+    protected function setUp()
+    {
+        self::$env = array();
+
+        $this->mockBuilder = $this->getMockBuilder('PHPCI\Builder')->disableOriginalConstructor()->getMock();
+
+        $this->mockBuilder->expects($this->never())->method('logFailure');
+
+        $this->mockBuild = $this->getMock('PHPCI\Model\Build');
+
+        $this->mockInterpolator = $this->getMock('PHPCI\Helper\BuildInterpolator');
+
+        $this->mockInterpolator
+            ->expects($this->any())
+            ->method('interpolate')
+            ->willReturnCallback(function($value) { return "X$value"; });
+
+        $this->testedEnvPlugin = new EnvPlugin(
+            $this->mockBuilder,
+            $this->mockBuild,
+            $this->mockInterpolator,
+            array(
+                'FOO=BAR',
+                "FOO2" => "BAR2",
+                array("FOO3" => "BAR3")
+            )
+        );
+    }
+
+    public function testExecute_PutEnv()
+    {
+        $this->mockInterpolator
+            ->expects($this->exactly(6))
+            ->method('interpolate')
+            ->withConsecutive(['FOO'], ['BAR'], ['FOO2'], ['BAR2'], ['FOO3'], ['BAR3']);
+
+        $this->assertTrue($this->testedEnvPlugin->execute());
+
+        $this->assertEquals("XBAR", self::$env["XFOO"]);
+        $this->assertEquals("XBAR2", self::$env["XFOO2"]);
+        $this->assertEquals("XBAR3", self::$env["XFOO3"]);
+    }
+
+    public function testExecute_SetInterpolationVar()
+    {
+        $this->mockInterpolator
+            ->expects($this->exactly(3))
+            ->method('setInterpolationVar')
+            ->withConsecutive(['XFOO', 'XBAR'], ['XFOO2', 'XBAR2'], ['XFOO3', 'XBAR3']);
+
+        $this->assertTrue($this->testedEnvPlugin->execute());
+    }
+
+}
+
+// Create a "putenv" function in the PHPCI\Plugin namespace.
+namespace PHPCI\Plugin;
+
+/**
+ * Mock the global function "putenv".
+ *
+ * @param string $var
+ * @return boolean
+ */
+function putenv($var)
+{
+    list($name, $value) = explode("=", $var, 2);
+    \PHPCI\Plugin\Tests\EnvTest::$env[$name] = $value;
+    return true;
+}


### PR DESCRIPTION
This PR makes the Env plugin pushes the variables into the interpolator, so they can also be used to configure the other plugins.

