### PR TITLE
Fixed the install script, which bails-out with an error if the PHPCI path contains spaces.

### DIFF
--- a/PHPCI/Command/InstallCommand.php
+++ b/PHPCI/Command/InstallCommand.php
@@ -323,8 +323,8 @@ class InstallCommand extends Command
     {
         $output->write(Lang::get('setting_up_db'));
 
-		$phinxBinary = escapeshellarg(PHPCI_DIR . 'vendor/bin/phinx');
-		$phinxScript = escapeshellarg(PHPCI_DIR . 'phinx.php');
+        $phinxBinary = escapeshellarg(PHPCI_DIR . 'vendor/bin/phinx');
+        $phinxScript = escapeshellarg(PHPCI_DIR . 'phinx.php');
         shell_exec($phinxBinary . ' migrate -c ' . $phinxScript);
 
         $output->writeln('<info>'.Lang::get('ok').'</info>');

--- a/PHPCI/Command/InstallCommand.php
+++ b/PHPCI/Command/InstallCommand.php
@@ -323,7 +323,9 @@ class InstallCommand extends Command
     {
         $output->write(Lang::get('setting_up_db'));
 
-        shell_exec(PHPCI_DIR . 'vendor/bin/phinx migrate -c "' . PHPCI_DIR . 'phinx.php"');
+		$phinxBinary = escapeshellarg(PHPCI_DIR . 'vendor/bin/phinx');
+		$phinxScript = escapeshellarg(PHPCI_DIR . 'phinx.php');
+        shell_exec($phinxBinary . ' migrate -c ' . $phinxScript);
 
         $output->writeln('<info>'.Lang::get('ok').'</info>');
     }


### PR DESCRIPTION
This occurs commonly on Windows, but from my reading of the code it would also be a problem on other platforms if spaces were present (though this is less likely, due to different naming conventions).

It has been fixed by using escapeshellarg() on both of the paths used in the command.

Fixes #698, which I've just noticed has a similar solution suggested in one of the comments, but was closed without anyone actually implementing it.