### PR TITLE
Fix issue #840 Technical Debt not storing data nor displaying results in...

### DIFF
--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -207,5 +207,7 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
                 }
             }
         }
+        
+        return array( $errorCount, $data );
     }
 }


### PR DESCRIPTION
Regarding #840  - getErrorList() wasn't returning an array of data, causing the error data not to be logged.