### PR TITLE
Symlinks removed incorrectly. Fixed.

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -223,7 +223,7 @@ class Builder implements LoggerAwareInterface
             if (IS_WIN) {
                 $cmd = 'rmdir /S /Q "%s"';
             }
-            $this->executeCommand($cmd, $this->buildPath);
+            $this->executeCommand($cmd, rtrim($this->buildPath, '/'));
         } catch (\Exception $ex) {
             $this->build->setStatus(Build::STATUS_FAILED);
             $this->buildLogger->logFailure(Lang::get('exception') . $ex->getMessage());


### PR DESCRIPTION
For a project of type "Local Path" with the "prefer_symlink: true," when the build is removed (i.e. completed), not the symlink was removed, but the location it points to, i.e. the original repository.