### PR TITLE
Remove short array syntax to keep backwards compatibility with php5.3

### DIFF
--- a/PHPCI/Application.php
+++ b/PHPCI/Application.php
@@ -51,7 +51,7 @@ class Application extends b8\Application
             return false;
         };
 
-        $skipAuth = [$this, 'shouldSkipAuth'];
+        $skipAuth = array($this, 'shouldSkipAuth');
 
         // Handler for the route we're about to register, checks for a valid session where necessary:
         $routeHandler = function (&$route, Response &$response) use (&$request, $validateSession, $skipAuth) {

--- a/PHPCI/Controller/SettingsController.php
+++ b/PHPCI/Controller/SettingsController.php
@@ -351,7 +351,7 @@ class SettingsController extends Controller
         $form->addField($field);
 
         $field = new Form\Element\Select('smtp_encryption');
-        $field->setOptions(['' => Lang::get('none'), 'tls' => Lang::get('tls'), 'ssl' => Lang::get('ssl')]);
+        $field->setOptions(array('' => Lang::get('none'), 'tls' => Lang::get('tls'), 'ssl' => Lang::get('ssl')));
         $field->setRequired(false);
         $field->setLabel(Lang::get('use_smtp_encryption'));
         $field->setContainerClass('form-group');
@@ -406,13 +406,13 @@ class SettingsController extends Controller
         $field->setLabel(Lang::get('failed_after'));
         $field->setClass('form-control');
         $field->setContainerClass('form-group');
-        $field->setOptions([
+        $field->setOptions(array(
             300 => Lang::get('5_mins'),
             900 => Lang::get('15_mins'),
             1800 => Lang::get('30_mins'),
             3600 => Lang::get('1_hour'),
             10800 => Lang::get('3_hours'),
-        ]);
+        ));
         $field->setValue(1800);
         $form->addField($field);
 

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -152,7 +152,7 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     {
         $dirIterator = new \RecursiveDirectoryIterator($this->directory);
         $iterator = new \RecursiveIteratorIterator($dirIterator, \RecursiveIteratorIterator::SELF_FIRST);
-        $files = [];
+        $files = array();
 
         $ignores = $this->ignore;
         $ignores[] = 'phpci.yml';
@@ -207,7 +207,7 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
                 }
             }
         }
-        
+
         return array( $errorCount, $data );
     }
 }


### PR DESCRIPTION
Fix for #852