### PR TITLE
Added dbunit to PHPCI's composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
 
     "require-dev": {
         "phpunit/phpunit": "~4.0",
+        "phpunit/dbunit": ">=1.2",
         "phpspec/prophecy-phpunit": "~1.0",
         "phpmd/phpmd": "~2.0",
         "squizlabs/php_codesniffer": "~2.0",


### PR DESCRIPTION
PHPCI comes with its own version of phpunit, but doesn't include dbunit.

My local phpunit installation includes dbunit by default. Because of this, tests would run locally but fail remotely when executed by PHPCI.

I added dbunit to composer, so that PHPCI's phpunit would run tests like a regular phpunit installation.