### PR TITLE
Cleanup technical debt

### DIFF
--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -193,7 +193,6 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
                     $content = trim($allLines[$lineNumber - 1]);
 
                     $errorCount++;
-                    $this->phpci->log("Found $search on line $lineNumber of $file:\n$content");
 
                     $fileName = str_replace($this->directory, '', $file);
                     $data[] = array(


### PR DESCRIPTION
Just a small one to remove the output from the build log

This causes problems when finding TODO or FIXME in HTML files and potentially in JS files as the build log is not made HTML safe.

It also is inconsistent with the other plugins which don't pollute the build log with output unless they don't also have a UI plugin