### PR TITLE
Preventing the wipe plugin failing due to an undefined variable

### DIFF
--- a/PHPCI/Plugin/Wipe.php
+++ b/PHPCI/Plugin/Wipe.php
@@ -61,8 +61,8 @@ class Wipe implements \PHPCI\Plugin
             if (IS_WIN) {
                 $cmd = 'rmdir /S /Q "%s"';
             }
-            $success = $this->phpci->executeCommand($cmd, $this->directory);
+            return $this->phpci->executeCommand($cmd, $this->directory);
         }
-        return $success;
+        return true;
     }
 }


### PR DESCRIPTION
I was having problems due to $success being undefined if the directory does not exist, i.e. if it is a directory which is created by the build process and this is the first build