### PR TITLE
Detailled webhook responses

### DIFF
--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -338,8 +338,14 @@ class WebhookController extends \b8\Controller
      *
      * @throws \Exception
      */
-    protected function createBuild(Project $project, $commitId, $branch, $committer, $commitMessage, array $extra = null)
-    {
+    protected function createBuild(
+        Project $project,
+        $commitId,
+        $branch,
+        $committer,
+        $commitMessage,
+        array $extra = null
+    ) {
         // Check if a build already exists for this commit ID:
         $builds = $this->buildStore->getByProjectAndCommit($project->getId(), $commitId);
 

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -118,7 +118,7 @@ class WebhookController extends \b8\Controller
      */
     public function git($projectId)
     {
-        $project = $this->fetchProject($projectId, 'git');
+        $project = $this->fetchProject($projectId, array('local', 'remote'));
         $branch = $this->getParam('branch', $project->getBranch());
         $commit = $this->getParam('commit');
         $commitMessage = $this->getParam('message');
@@ -374,7 +374,7 @@ class WebhookController extends \b8\Controller
      * Fetch a project and check its type.
      *
      * @param int $projectId
-     * @param string $expectedType
+     * @param array|string $expectedType
      *
      * @return Project
      *
@@ -388,7 +388,10 @@ class WebhookController extends \b8\Controller
             throw new Exception('Project does not exist: ' . $projectId);
         }
 
-        if ($project->getType() !== $expectedType) {
+        if (is_array($expectedType)
+            ? !in_array($project->getType(), $expectedType)
+            : $project->getType() !== $expectedType
+        ) {
             throw new Exception('Wrong project type: ' . $project->getType());
         }
 

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -2,7 +2,7 @@
 /**
  * PHPCI - Continuous Integration for PHP
  *
- * @copyright    Copyright 2014, Block 8 Limited.
+ * @copyright    Copyright 2014-2015, Block 8 Limited.
  * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
  * @link         https://www.phptesting.org/
  */
@@ -16,9 +16,11 @@ use PHPCI\Service\BuildService;
 
 /**
  * Webhook Controller - Processes webhook pings from BitBucket, Github, Gitlab, etc.
+ *
  * @author       Dan Cryer <dan@block8.co.uk>
  * @author       Sami Tikka <stikka@iki.fi>
  * @author       Alex Russell <alex@clevercherry.com>
+ * @author       Guillaume Perréal <adirelle@gmail.com>
  * @package      PHPCI
  * @subpackage   Web
  */
@@ -157,9 +159,11 @@ class WebhookController extends \PHPCI\Controller
 
     /**
      * Handle the payload when Github sends a commit webhook.
+     *
      * @param $project
      * @param array $payload
      * @param b8\Http\Response\JsonResponse $response
+     *
      * @return b8\Http\Response\JsonResponse
      */
     protected function githubCommitRequest($project, array $payload, b8\Http\Response\JsonResponse $response)
@@ -208,6 +212,7 @@ class WebhookController extends \PHPCI\Controller
 
     /**
      * Handle the payload when Github sends a Pull Request webhook.
+     *
      * @param $projectId
      * @param array $payload
      */
@@ -320,12 +325,14 @@ class WebhookController extends \PHPCI\Controller
 
     /**
      * Wrapper for creating a new build.
+     *
      * @param $projectId
      * @param $commitId
      * @param $branch
      * @param $committer
      * @param $commitMessage
      * @param null $extra
+     *
      * @return bool
      * @throws \Exception
      */

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -11,8 +11,12 @@ namespace PHPCI\Controller;
 
 use b8;
 use b8\Store;
+use Exception;
 use PHPCI\BuildFactory;
+use PHPCI\Model\Project;
 use PHPCI\Service\BuildService;
+use PHPCI\Store\BuildStore;
+use PHPCI\Store\ProjectStore;
 
 /**
  * Webhook Controller - Processes webhook pings from BitBucket, Github, Gitlab, etc.
@@ -27,17 +31,17 @@ use PHPCI\Service\BuildService;
 class WebhookController extends \b8\Controller
 {
     /**
-     * @var \PHPCI\Store\BuildStore
+     * @var BuildStore
      */
     protected $buildStore;
 
     /**
-     * @var \PHPCI\Store\ProjectStore
+     * @var ProjectStore
      */
     protected $projectStore;
 
     /**
-     * @var \PHPCI\Service\BuildService
+     * @var BuildService
      */
     protected $buildService;
 
@@ -68,7 +72,7 @@ class WebhookController extends \b8\Controller
                 unset($data['responseCode']);
             }
             $response->setContent($data);
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             $response->setResponseCode(500);
             $response->setContent(array('status' => 'failed', 'error' => $ex->getMessage()));
         }
@@ -99,7 +103,7 @@ class WebhookController extends \b8\Controller
                     $commit['message']
                 );
                 $status = 'ok';
-            } catch (\Exception $ex) {
+            } catch (Exception $ex) {
                 $results[$commit['raw_node']] = array('status' => 'failed', 'error' => $ex->getMessage());
             }
         }
@@ -193,7 +197,7 @@ class WebhookController extends \b8\Controller
                         $commit['message']
                     );
                     $status = 'ok';
-                } catch (\Exception $ex) {
+                } catch (Exception $ex) {
                     $results[$commit['id']] = array('status' => 'failed', 'error' => $ex->getMessage());
                 }
             }
@@ -238,7 +242,7 @@ class WebhookController extends \b8\Controller
 
         // Check we got a success response:
         if (!$response['success']) {
-            throw new \Exception('Could not get commits, failed API request.');
+            throw new Exception('Could not get commits, failed API request.');
         }
 
         $results = array();
@@ -266,7 +270,7 @@ class WebhookController extends \b8\Controller
 
                 $results[$id] = $this->createBuild($project, $id, $branch, $committer, $message, $extra);
                 $status = 'ok';
-            } catch (\Exception $ex) {
+            } catch (Exception $ex) {
                 $results[$id] = array('status' => 'failed', 'error' => $ex->getMessage());
             }
         }
@@ -314,7 +318,7 @@ class WebhookController extends \b8\Controller
                         $commit['message']
                     );
                     $status = 'ok';
-                } catch (\Exception $ex) {
+                } catch (Exception $ex) {
                     $results[$commit['id']] = array('status' => 'failed', 'error' => $ex->getMessage());
                 }
             }
@@ -336,7 +340,7 @@ class WebhookController extends \b8\Controller
      *
      * @return array
      *
-     * @throws \Exception
+     * @throws Exception
      */
     protected function createBuild(
         Project $project,
@@ -374,18 +378,18 @@ class WebhookController extends \b8\Controller
      *
      * @return Project
      *
-     * @throws \Exception If the project does not exist or is not of the expected type.
+     * @throws Exception If the project does not exist or is not of the expected type.
      */
     protected function fetchProject($projectId, $expectedType)
     {
         $project = $this->projectStore->getById($projectId);
 
         if (empty($projectId)) {
-            throw new \Exception('Project does not exist:' . $projectId);
+            throw new Exception('Project does not exist: ' . $projectId);
         }
 
         if ($project->getType() !== $expectedType) {
-            throw new \Exception('Wrong project type:' . $project->getType());
+            throw new Exception('Wrong project type: ' . $project->getType());
         }
 
         return $project;

--- a/Tests/PHPCI/Controller/WebhookControllerTest.php
+++ b/Tests/PHPCI/Controller/WebhookControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCI - Continuous Integration for PHP
+ *
+ * @copyright    Copyright 2014, Block 8 Limited.
+ * @license        https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ * @link            http://www.phptesting.org/
+ */
+
+namespace PHPCI\Tests\Controller;
+
+use PHPCI\Controller\WebhookController;
+use Prophecy\PhpUnit\ProphecyTestCase;
+
+class WebhookControllerTest extends ProphecyTestCase
+{
+    public function test_wrong_action_name_return_json_with_error()
+    {
+        $webController = new WebhookController(
+            $this->prophesize('b8\Config')->reveal(),
+            $this->prophesize('b8\Http\Request')->reveal(),
+            $this->prophesize('b8\Http\Response')->reveal()
+        );
+
+        $error = $webController->handleAction('test', []);
+
+        $this->assertInstanceOf('b8\Http\Response\JsonResponse', $error);
+
+        $responseData = $error->getData();
+        $this->assertEquals(500, $responseData['code']);
+
+        $this->assertEquals('failed', $responseData['body']['status']);
+
+        $this->assertEquals('application/json', $responseData['headers']['Content-Type']);
+
+        // @todo: we can't text the result is JSON file with
+        //   $this->assertJson((string) $error);
+        // since the flush method automatically add the header and break the
+        // testing framework.
+    }
+}


### PR DESCRIPTION
Add details to webhook responses, namely:
* Add the build id when a build is actually created in response to the hook,
* Tell if the build is ignored, and for which reason,
* For hooks submitting several commits, collect the results of each commit in a "commit" object.