### PR TITLE
Error handler fixes

### DIFF
--- a/PHPCI/ErrorHandler.php
+++ b/PHPCI/ErrorHandler.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * PHPCI - Continuous Integration for PHP
+ *
+ * @copyright    Copyright 2014, Block 8 Limited.
+ * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ * @link         https://www.phptesting.org/
+ */
+
+namespace PHPCI;
+
+/**
+ * Error Handler
+ *
+ * @package PHPCI\Logging
+ */
+class ErrorHandler
+{
+    /**
+     * @var array
+     */
+    protected $levels = array(
+        E_WARNING           => 'Warning',
+        E_NOTICE            => 'Notice',
+        E_USER_ERROR        => 'User Error',
+        E_USER_WARNING      => 'User Warning',
+        E_USER_NOTICE       => 'User Notice',
+        E_STRICT            => 'Runtime Notice',
+        E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
+        E_DEPRECATED        => 'Deprecated',
+        E_USER_DEPRECATED   => 'User Deprecated',
+    );
+
+    /**
+     * Registers an instance of the error handler to throw ErrorException.
+     */
+    public static function register()
+    {
+        $handler = new static();
+        set_error_handler(array($handler, 'handleError'));
+    }
+
+    /**
+     * @param integer $level
+     * @param string  $message
+     * @param string  $file
+     * @param integer $line
+     *
+     * @throws \ErrorException
+     *
+     * @internal
+     */
+    public function handleError($level, $message, $file, $line)
+    {
+        if (error_reporting() & $level === 0) {
+            return;
+        }
+
+        $exceptionLevel = isset($this->levels[$level]) ? $this->levels[$level] : $level;
+        throw new \ErrorException(
+            sprintf('%s: %s in %s line %d', $exceptionLevel, $message, $file, $line),
+            0,
+            $level,
+            $file,
+            $line
+        );
+    }
+}

--- a/PHPCI/Logging/LoggerConfig.php
+++ b/PHPCI/Logging/LoggerConfig.php
@@ -19,6 +19,7 @@ class LoggerConfig
 {
     const KEY_ALWAYS_LOADED = "_";
     private $config;
+    private $cache = array();
 
     /**
      * The filepath is expected to return an array which will be
@@ -56,9 +57,20 @@ class LoggerConfig
      */
     public function getFor($name)
     {
+        if (isset($this->cache[$name])) {
+            return $this->cache[$name];
+        }
+
         $handlers = $this->getHandlers(self::KEY_ALWAYS_LOADED);
-        $handlers = array_merge($handlers, $this->getHandlers($name));
-        return new Logger($name, $handlers);
+        if ($name !== self::KEY_ALWAYS_LOADED) {
+            $handlers = array_merge($handlers, $this->getHandlers($name));
+        }
+
+        $logger = new Logger($name, $handlers);
+        Handler::getInstance()->register($logger);
+        $this->cache[$name] = $logger;
+
+        return $logger;
     }
 
     /**

--- a/PHPCI/Logging/LoggerConfig.php
+++ b/PHPCI/Logging/LoggerConfig.php
@@ -9,6 +9,7 @@
 
 namespace PHPCI\Logging;
 
+use Monolog\ErrorHandler;
 use Monolog\Logger;
 
 /**
@@ -67,7 +68,7 @@ class LoggerConfig
         }
 
         $logger = new Logger($name, $handlers);
-        Handler::getInstance()->register($logger);
+        ErrorHandler::register($logger);
         $this->cache[$name] = $logger;
 
         return $logger;

--- a/Tests/PHPCI/Logging/LoggerConfigTest.php
+++ b/Tests/PHPCI/Logging/LoggerConfigTest.php
@@ -81,5 +81,14 @@ class LoggerConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedHandler, $actualHandler);
         $this->assertNotSame($alternativeHandler, $actualHandler);
     }
-}
 
+    public function testGetFor_SameInstance()
+    {
+        $config = new LoggerConfig(array());
+
+        $logger1 = $config->getFor("something");
+        $logger2 = $config->getFor("something");
+
+        $this->assertSame($logger1, $logger2);
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,7 +8,6 @@
 */
 
 // Let PHP take a guess as to the default timezone, if the user hasn't set one:
-use PHPCI\Logging\Handler;
 use PHPCI\Logging\LoggerConfig;
 
 $timezone = ini_get('date.timezone');
@@ -43,9 +42,10 @@ if (!file_exists(dirname(__FILE__) . '/vendor/autoload.php') && defined('PHPCI_I
 // Load Composer autoloader:
 require_once(dirname(__FILE__) . '/vendor/autoload.php');
 
+\PHPCI\ErrorHandler::register();
+
 if (defined('PHPCI_IS_CONSOLE') && PHPCI_IS_CONSOLE) {
     $loggerConfig = LoggerConfig::newFromFile(__DIR__ . "/loggerconfig.php");
-    Handler::register($loggerConfig->getFor('_'));
 }
 
 // Load configuration if present:

--- a/daemonise
+++ b/daemonise
@@ -15,8 +15,6 @@ require('bootstrap.php');
 use PHPCI\Command\DaemoniseCommand;
 use Symfony\Component\Console\Application;
 
-$loggerConfig = \PHPCI\Logging\LoggerConfig::newFromFile(__DIR__ . "/loggerconfig.php");
-
 $application = new Application();
 $application->add(new DaemoniseCommand($loggerConfig->getFor('DaemoniseCommand')));
 $application->run();


### PR DESCRIPTION
A couple of changes to ensure the error/exception handler is registered and forwards the error logs to any logger created by LoggerConfig::getFor.

Moreover, LoggerConfig::getFor always returns the same instance of Logger for the same $name. This ensures calls to pushHandler & pushProcessor are not "lost" between successive calls to getFor.