### PR TITLE
Added check for valid Github key on settings page

### DIFF
--- a/PHPCI/View/Settings/index.phtml
+++ b/PHPCI/View/Settings/index.phtml
@@ -57,7 +57,7 @@
                 }
 
                 $returnTo = PHPCI_URL . 'settings/github-callback';
-                $githubUri = 'https://github.com/login/oauth/authorize?client_id='.$id.'&scope=repo,write:public_key&redirect_uri=' . $returnTo;
+                $githubUri = 'https://github.com/login/oauth/authorize?client_id='.$id.'&scope=repo&redirect_uri=' . $returnTo;
                 ?>
                 <?php if (!empty($id)): ?>
                     <?php if (empty($githubUser['name']) || empty($settings['phpci']['github']['token'])): ?>

--- a/PHPCI/View/Settings/index.phtml
+++ b/PHPCI/View/Settings/index.phtml
@@ -57,22 +57,22 @@
                 }
 
                 $returnTo = PHPCI_URL . 'settings/github-callback';
-                $githubUri = 'https://github.com/login/oauth/authorize?client_id='.$id.'&scope=repo&redirect_uri=' . $returnTo;
+                $githubUri = 'https://github.com/login/oauth/authorize?client_id='.$id.'&scope=repo,write:public_key&redirect_uri=' . $returnTo;
                 ?>
-                <?php if (!empty($id) && empty($settings['phpci']['github']['token'])): ?>
-                    <p class="alert alert-warning clearfix">
-                        <?php Lang::out('github_sign_in', $githubUri); ?>
-                    </p>
-                <?php endif; ?>
+                <?php if (!empty($id)): ?>
+                    <?php if (empty($githubUser['name']) || empty($settings['phpci']['github']['token'])): ?>
+                        <p class="alert alert-warning clearfix">
+                            <?php Lang::out('github_sign_in', $githubUri); ?>
+                        </p>
+                    <?php else: ?>
+                        <p class="alert alert-success">
+                            <?php Lang::out('github_phpci_linked'); ?>
 
-                <?php if (!empty($id) && !empty($settings['phpci']['github']['token'])): ?>
-                    <p class="alert alert-success">
-                        <?php Lang::out('github_phpci_linked'); ?>
-
-                        <strong>
-                            <a href="<?php echo $githubUser['html_url']; ?>"><?php echo $githubUser['name']; ?></a>
-                        </strong>
-                    </p>
+                            <strong>
+                                <a href="<?php echo $githubUser['html_url']; ?>"><?php echo $githubUser['name']; ?></a>
+                            </strong>
+                        </p>
+                    <?php endif; ?>
                 <?php endif; ?>
             </div>
 


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: front-end

Description of change:
If someone revokes their GitHub OAUTH key, or changes their application details then it invalidates the OAUTH token in PHPCI. The settings page didn't check the OAUTH key is still valid before showing the success dialog, meaning there was no way to authenticate again (without editing their database).

Description of solution:
This PR changes the UI to show the login message when the key is missing or is invalid. 