### PR TITLE
[WIP] Added ability to configure the executable to all plugins.

### DIFF
--- a/PHPCI/Plugin/Atoum.php
+++ b/PHPCI/Plugin/Atoum.php
@@ -35,7 +35,7 @@ class Atoum implements \PHPCI\Plugin
         $this->build = $build;
 
         if (isset($options['executable'])) {
-            $this->executable = $this->phpci->buildPath . DIRECTORY_SEPARATOR.$options['executable'];
+            $this->executable = $options['executable'];
         } else {
             $this->executable = $this->phpci->findBinary('atoum');
         }

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -49,6 +49,7 @@ class Codeception implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      * @var string The path where the reports and logs are stored
      */
     protected $logPath = 'tests/_output';
+    protected $executable;
 
     /**
      * Set up the plugin, configure options, etc.
@@ -72,6 +73,12 @@ class Codeception implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
         if (isset($options['log_path'])) {
             $this->logPath = $options['log_path'];
+        }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('codecept');
         }
     }
 
@@ -131,7 +138,7 @@ class Codeception implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         if (is_array($configPath)) {
             return $this->recurseArg($configPath, array($this, 'runConfigFile'));
         } else {
-            $codecept = $this->phpci->findBinary('codecept');
+            $codecept = $this->executable;
 
             if (!$codecept) {
                 $this->phpci->logFailure(Lang::get('could_not_find', 'codecept'));

--- a/PHPCI/Plugin/Composer.php
+++ b/PHPCI/Plugin/Composer.php
@@ -27,6 +27,7 @@ class Composer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     protected $preferDist;
     protected $phpci;
     protected $build;
+    protected $executable;
 
     /**
      * Check if this plugin can be executed.
@@ -72,6 +73,12 @@ class Composer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         if (array_key_exists('prefer_dist', $options)) {
             $this->preferDist = (bool)$options['prefer_dist'];
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary(array('composer', 'composer.phar'));
+        }
     }
 
     /**
@@ -79,7 +86,7 @@ class Composer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     */
     public function execute()
     {
-        $composerLocation = $this->phpci->findBinary(array('composer', 'composer.phar'));
+        $composerLocation = $this->executable;
 
         if (!$composerLocation) {
             $this->phpci->logFailure(Lang::get('could_not_find', 'composer'));

--- a/PHPCI/Plugin/Grunt.php
+++ b/PHPCI/Plugin/Grunt.php
@@ -25,7 +25,7 @@ class Grunt implements \PHPCI\Plugin
     protected $preferDist;
     protected $phpci;
     protected $build;
-    protected $grunt;
+    protected $executable;
     protected $gruntfile;
 
     /**
@@ -47,7 +47,6 @@ class Grunt implements \PHPCI\Plugin
         $this->phpci = $phpci;
         $this->directory = $path;
         $this->task = null;
-        $this->grunt = $this->phpci->findBinary('grunt');
         $this->gruntfile = 'Gruntfile.js';
 
         // Handle options:
@@ -66,6 +65,12 @@ class Grunt implements \PHPCI\Plugin
         if (isset($options['gruntfile'])) {
             $this->gruntfile = $options['gruntfile'];
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('grunt');
+        }
     }
 
     /**
@@ -83,9 +88,9 @@ class Grunt implements \PHPCI\Plugin
         }
 
         // build the grunt command
-        $cmd = 'cd %s && ' . $this->grunt;
+        $cmd = 'cd %s && ' . $this->executable;
         if (IS_WIN) {
-            $cmd = 'cd /d %s && ' . $this->grunt;
+            $cmd = 'cd /d %s && ' . $this->executable;
         }
         $cmd .= ' --no-color';
         $cmd .= ' --gruntfile %s';

--- a/PHPCI/Plugin/Gulp.php
+++ b/PHPCI/Plugin/Gulp.php
@@ -25,7 +25,7 @@ class Gulp implements \PHPCI\Plugin
     protected $preferDist;
     protected $phpci;
     protected $build;
-    protected $gulp;
+    protected $executable;
     protected $gulpfile;
 
     /**
@@ -47,7 +47,6 @@ class Gulp implements \PHPCI\Plugin
         $this->phpci = $phpci;
         $this->directory = $path;
         $this->task = null;
-        $this->gulp = $this->phpci->findBinary('gulp');
         $this->gulpfile = 'gulpfile.js';
 
         // Handle options:
@@ -66,6 +65,12 @@ class Gulp implements \PHPCI\Plugin
         if (isset($options['gulpfile'])) {
             $this->gulpfile = $options['gulpfile'];
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('gulp');
+        }
     }
 
     /**
@@ -83,9 +88,9 @@ class Gulp implements \PHPCI\Plugin
         }
 
         // build the gulp command
-        $cmd = 'cd %s && ' . $this->gulp;
+        $cmd = 'cd %s && ' . $this->executable;
         if (IS_WIN) {
-            $cmd = 'cd /d %s && ' . $this->gulp;
+            $cmd = 'cd /d %s && ' . $this->executable;
         }
         $cmd .= ' --no-color';
         $cmd .= ' --gulpfile %s';

--- a/PHPCI/Plugin/Lint.php
+++ b/PHPCI/Plugin/Lint.php
@@ -26,6 +26,7 @@ class Lint implements PHPCI\Plugin
     protected $ignore;
     protected $phpci;
     protected $build;
+    protected $executable;
 
     /**
      * Standard Constructor
@@ -57,6 +58,12 @@ class Lint implements PHPCI\Plugin
         if (array_key_exists('recursive', $options)) {
             $this->recursive = $options['recursive'];
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('php');
+        }
     }
 
     /**
@@ -67,7 +74,7 @@ class Lint implements PHPCI\Plugin
         $this->phpci->quiet = true;
         $success = true;
 
-        $php = $this->phpci->findBinary('php');
+        $php = $this->executable;
 
         foreach ($this->directories as $dir) {
             if (!$this->lintDirectory($php, $dir)) {

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -47,6 +47,7 @@ class Pdepend implements \PHPCI\Plugin
      *             in the readme.md of the repository
      */
     protected $location;
+    protected $executable;
 
     /**
      * Set up the plugin, configure options, etc.
@@ -66,6 +67,12 @@ class Pdepend implements \PHPCI\Plugin
         $this->pyramid  = $title . '-pyramid.svg';
         $this->chart    = $title . '-chart.svg';
         $this->location = $this->phpci->buildPath . '..' . DIRECTORY_SEPARATOR . 'pdepend';
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('pdepend');
+        }
     }
 
     /**
@@ -77,7 +84,7 @@ class Pdepend implements \PHPCI\Plugin
             throw new \Exception(sprintf('The location %s is not writable.', $this->location));
         }
 
-        $pdepend = $this->phpci->findBinary('pdepend');
+        $pdepend = $this->executable;
 
         if (!$pdepend) {
             $this->phpci->logFailure(Lang::get('could_not_find', 'pdepend'));

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -29,6 +29,9 @@ class Phing implements \PHPCI\Plugin
     private $properties = array();
     private $propertyFile;
 
+    /**
+     * @var \PHPCI\Builder
+     */
     protected $phpci;
     protected $build;
 
@@ -72,6 +75,12 @@ class Phing implements \PHPCI\Plugin
         if (isset($options['property_file'])) {
             $this->setPropertyFile($options['property_file']);
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('phing');
+        }
     }
 
     /**
@@ -79,7 +88,7 @@ class Phing implements \PHPCI\Plugin
      */
     public function execute()
     {
-        $phingExecutable = $this->phpci->findBinary('phing');
+        $phingExecutable = $this->executable;
 
         if (!$phingExecutable) {
             $this->phpci->logFailure(Lang::get('could_not_find', 'phing'));

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -124,6 +124,12 @@ class PhpCodeSniffer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
             $this->encoding = ' --encoding=' . $options['encoding'];
         }
 
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('phpcs');
+        }
+
         $this->setOptions($options);
     }
 
@@ -147,7 +153,7 @@ class PhpCodeSniffer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     {
         list($ignore, $standard, $suffixes) = $this->getFlags();
 
-        $phpcs = $this->phpci->findBinary('phpcs');
+        $phpcs = $this->executable;
 
         if (!$phpcs) {
             $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpcs'));

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -36,6 +36,7 @@ class PhpCpd implements \PHPCI\Plugin
      * @var array - paths to ignore
      */
     protected $ignore;
+    protected $executable;
 
     /**
      * Set up the plugin, configure options, etc.
@@ -63,6 +64,12 @@ class PhpCpd implements \PHPCI\Plugin
         if (!empty($options['ignore'])) {
             $this->ignore = $options['ignore'];
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('phpcpd');
+        }
     }
 
     /**
@@ -88,7 +95,7 @@ class PhpCpd implements \PHPCI\Plugin
             $ignore = implode('', $ignore);
         }
 
-        $phpcpd = $this->phpci->findBinary('phpcpd');
+        $phpcpd = $this->executable;
 
         if (!$phpcpd) {
             $this->phpci->logFailure(Lang::get('could_not_find', 'phpcpd'));

--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -36,6 +36,8 @@ class PhpCsFixer implements \PHPCI\Plugin
     protected $verbose    = '';
     protected $diff       = '';
     protected $levels     = array('psr0', 'psr1', 'psr2', 'all');
+    protected $workingdir;
+    protected $executable;
 
     /**
      * Standard Constructor
@@ -67,7 +69,7 @@ class PhpCsFixer implements \PHPCI\Plugin
         $curdir = getcwd();
         chdir($this->workingdir);
 
-        $phpcsfixer = $this->phpci->findBinary('php-cs-fixer');
+        $phpcsfixer = $this->executable;
 
         if (!$phpcsfixer) {
             $this->phpci->logFailure(Lang::get('could_not_find', 'php-cs-fixer'));
@@ -88,6 +90,12 @@ class PhpCsFixer implements \PHPCI\Plugin
      */
     public function buildArgs($options)
     {
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('php-cs-fixer');
+        }
+
         if (isset($options['verbose']) && $options['verbose']) {
             $this->verbose = ' --verbose';
         }

--- a/PHPCI/Plugin/PhpDocblockChecker.php
+++ b/PHPCI/Plugin/PhpDocblockChecker.php
@@ -44,6 +44,7 @@ class PhpDocblockChecker implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
     protected $skipClasses = false;
     protected $skipMethods = false;
+    protected $executable;
 
     /**
      * Check if this plugin can be executed.
@@ -94,6 +95,12 @@ class PhpDocblockChecker implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         if (array_key_exists('allowed_warnings', $options)) {
             $this->allowed_warnings = (int)$options['allowed_warnings'];
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('phpdoccheck');
+        }
     }
 
     /**
@@ -102,7 +109,7 @@ class PhpDocblockChecker implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     public function execute()
     {
         // Check that the binary exists:
-        $checker = $this->phpci->findBinary('phpdoccheck');
+        $checker = $this->executable;
 
         if (!$checker) {
             $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpdoccheck'));

--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -29,6 +29,7 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      * @var \PHPCI\Builder
      */
     protected $phpci;
+    protected $executable;
 
     /**
      * Check if this plugin can be executed.
@@ -61,6 +62,12 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         if (isset($options['directory'])) {
             $this->directory .= $options['directory'];
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('phploc');
+        }
     }
 
     /**
@@ -78,7 +85,7 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
             $ignore = implode('', $ignore);
         }
 
-        $phploc = $this->phpci->findBinary('phploc');
+        $phploc = $this->executable;
 
         if (!$phploc) {
             $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phploc'));

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -54,6 +54,7 @@ class PhpMessDetector implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      * @var array
      */
     protected $rules;
+    protected $executable;
 
     /**
      * Check if this plugin can be executed.
@@ -108,6 +109,12 @@ class PhpMessDetector implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         foreach (array('rules', 'ignore', 'suffixes') as $key) {
             $this->overrideSetting($options, $key);
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('phpmd');
+        }
     }
 
     /**
@@ -119,7 +126,7 @@ class PhpMessDetector implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
             return false;
         }
 
-        $phpmdBinaryPath = $this->phpci->findBinary('phpmd');
+        $phpmdBinaryPath = $this->executable;
 
         if (!$phpmdBinaryPath) {
             $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpmd'));

--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -40,6 +40,7 @@ class PhpParallelLint implements \PHPCI\Plugin
      * @var array - paths to ignore
      */
     protected $ignore;
+    protected $executable;
 
     /**
      * Standard Constructor
@@ -67,6 +68,12 @@ class PhpParallelLint implements \PHPCI\Plugin
         if (isset($options['ignore'])) {
             $this->ignore = $options['ignore'];
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('parallel-lint');
+        }
     }
 
     /**
@@ -76,7 +83,7 @@ class PhpParallelLint implements \PHPCI\Plugin
     {
         list($ignore) = $this->getFlags();
 
-        $phplint = $this->phpci->findBinary('parallel-lint');
+        $phplint = $this->executable;
 
         if (!$phplint) {
             $this->phpci->logFailure(Lang::get('could_not_find', 'parallel-lint'));

--- a/PHPCI/Plugin/PhpSpec.php
+++ b/PHPCI/Plugin/PhpSpec.php
@@ -47,6 +47,12 @@ class PhpSpec implements PHPCI\Plugin
         $this->phpci = $phpci;
         $this->build = $build;
         $this->options = $options;
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary(array('phpspec', 'phpspec.php'));
+        }
     }
 
     /**
@@ -57,7 +63,7 @@ class PhpSpec implements PHPCI\Plugin
         $curdir = getcwd();
         chdir($this->phpci->buildPath);
 
-        $phpspec = $this->phpci->findBinary(array('phpspec', 'phpspec.php'));
+        $phpspec = $this->executable;
 
         if (!$phpspec) {
             $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpspec'));

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -135,6 +135,12 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         if (isset($options['coverage'])) {
             $this->coverage = " --coverage-html {$options['coverage']} ";
         }
+
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary(array('phpunit'));
+        }
     }
 
     /**
@@ -197,8 +203,7 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
                 chdir($this->phpci->buildPath.'/'.$this->runFrom);
             }
 
-
-            $phpunit = $this->phpci->findBinary('phpunit');
+            $phpunit = $this->executable;
 
             if (!$phpunit) {
                 $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpunit'));

--- a/PHPCI/Plugin/Xmpp.php
+++ b/PHPCI/Plugin/Xmpp.php
@@ -89,6 +89,12 @@ class XMPP implements \PHPCI\Plugin
             }
         }
 
+        if (isset($options['executable'])) {
+            $this->executable = $options['executable'];
+        } else {
+            $this->executable = $this->phpci->findBinary('/usr/bin/sendxmpp');
+        }
+
         $this->setOptions($options);
     }
 
@@ -148,7 +154,7 @@ class XMPP implements \PHPCI\Plugin
     */
     public function execute()
     {
-        $sendxmpp = $this->phpci->findBinary('/usr/bin/sendxmpp');
+        $sendxmpp = $this->executable;
 
         if (!$sendxmpp) {
             $this->phpci->logFailure('Could not find sendxmpp.');


### PR DESCRIPTION
Contribution Type: refactor
Primary Area: plugins

Description of change:
Some plugins let you override their executable, others don't. 

Description of solution:
For the sake of consistency and configurability, I've updated them all to allow the overriding of their executable. Ideally I'd like to move this logic to be automatic for each plugin (or usage of findBinary).

# TODO
- [x] Update individual plugins
- [ ] Update documentation
- [ ] Discuss feasibility of moving the executable overriding to `Builder::findBinary`
- [ ] Implement basic tests for each plugin

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/block8/phpci/896)
<!-- Reviewable:end -->
