### PR TITLE
[WIP] Added clean-up build status on command terminate/interrupt

### DIFF
--- a/PHPCI/Command/RunCommand.php
+++ b/PHPCI/Command/RunCommand.php
@@ -29,7 +29,7 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Console
 */
-class RunCommand extends Command
+class RunCommand extends SignaledCommand
 {
     /**
      * @var OutputInterface
@@ -52,6 +52,11 @@ class RunCommand extends Command
     protected $isFromDaemon = false;
 
     /**
+     * @var Build
+     */
+    private $currentBuild;
+
+    /**
      * @param \Monolog\Logger $logger
      * @param string $name
      */
@@ -63,15 +68,31 @@ class RunCommand extends Command
 
     protected function configure()
     {
+        parent::configure();
+
         $this
             ->setName('phpci:run-builds')
             ->setDescription(Lang::get('run_all_pending'));
     }
 
+    protected function stop()
+    {
+        parent::stop();
+
+        if ($this->currentBuild) {
+            $build = $this->currentBuild;
+
+            $build->setStatus(Build::STATUS_FAILED);
+            $build->setFinished(new \DateTime());
+            $build->setLog($build->getLog() . PHP_EOL . PHP_EOL . Lang::get('build_cancelled'));
+            Factory::getStore('Build')->save($build);
+        }
+    }
+
     /**
      * Pulls all pending builds from the database and runs them.
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function doExecute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
 
@@ -95,7 +116,7 @@ class RunCommand extends Command
 
         while (count($result['items'])) {
             $build = array_shift($result['items']);
-            $build = BuildFactory::getBuild($build);
+            $this->currentBuild = $build = BuildFactory::getBuild($build);
 
             // Skip build (for now) if there's already a build running in that project:
             if (!$this->isFromDaemon && in_array($build->getProjectId(), $running)) {
@@ -118,6 +139,7 @@ class RunCommand extends Command
                 $builder = new Builder($build, $this->logger);
                 $builder->execute();
 
+                $this->currentBuild = null;
                 // After execution we no longer want to record the information
                 // back to this specific build so the handler should be removed.
                 $this->logger->popHandler($buildDbLog);

--- a/PHPCI/Languages/lang.da.php
+++ b/PHPCI/Languages/lang.da.php
@@ -327,6 +327,7 @@ Kontrollér venligst nedenstående fejl før du fortsætter.',
     'last_commit_is' => 'Sidste commit til GitHub for %s er %s',
     'adding_new_build' => 'Sidste commit er forskellig fra databasen, tilføjer nyt build.',
     'finished_processing_builds' => 'Kørsel af builds afsluttet.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Tilføj en administrator',

--- a/PHPCI/Languages/lang.de.php
+++ b/PHPCI/Languages/lang.de.php
@@ -325,6 +325,7 @@ generiert. Um es zu verwenden, fügen Sie einfach den folgenden Public Key im Ab
     'last_commit_is' => 'Der letzte Commit zu GitHub für %s ist %s',
     'adding_new_build' => 'Letzter Commit unterscheidet sich von der Datenbank, füge neuen Build hinzu.',
     'finished_processing_builds' => 'Bearbeiten der Builds abgeschlossen.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Administratorenbenutzer erstellen',

--- a/PHPCI/Languages/lang.el.php
+++ b/PHPCI/Languages/lang.el.php
@@ -328,6 +328,7 @@ Services</a> του Bitbucket αποθετηρίου σας.',
     'last_commit_is' => 'H τελευταία συνεισφορά στο GitHub για %s είναι %s',
     'adding_new_build' => 'Τελευταία συνεισφορά είναι διαφορετική από τη βάση δεδομένων, γίνεται προσθήκη νέας κατασκευής.',
     'finished_processing_builds' => 'Ολοκληρώθηκε η επεξεργασία κατασκευής.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Δημιουργήστε ένα χρήστη διαχειριστή',

--- a/PHPCI/Languages/lang.en.php
+++ b/PHPCI/Languages/lang.en.php
@@ -332,6 +332,7 @@ PHPCI',
     'last_commit_is' => 'Last commit to GitHub for %s is %s',
     'adding_new_build' => 'Last commit is different to database, adding new build.',
     'finished_processing_builds' => 'Finished processing builds.',
+    'build_cancelled' => 'Build cancelled',
 
     // Create Admin
     'create_admin_user' => 'Create an admin user',

--- a/PHPCI/Languages/lang.fr.php
+++ b/PHPCI/Languages/lang.fr.php
@@ -329,6 +329,7 @@ PHPCI',
     'last_commit_is' => 'Le dernier commit sur GitHub pour %s est %s',
     'adding_new_build' => 'Le dernier commit est différent de celui présent en base de données, ajout d\'un nouveau build.',
     'finished_processing_builds' => 'Traitement des builds terminé.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Créer un utilisateur admin',

--- a/PHPCI/Languages/lang.it.php
+++ b/PHPCI/Languages/lang.it.php
@@ -331,6 +331,7 @@ PHPCI',
     'last_commit_is' => 'Ultimo commit su GitHub per %s è %s',
     'adding_new_build' => 'L\'ultimo commit è diverso da quello registrato, new build aggiunta.',
     'finished_processing_builds' => 'Terminato di processare le build.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Crea un nuovo utente amministrarore',

--- a/PHPCI/Languages/lang.nl.php
+++ b/PHPCI/Languages/lang.nl.php
@@ -329,6 +329,7 @@ Gelieve de fouten na te kijken vooraleer verder te gaan.',
     'last_commit_is' => 'Laatste commit naar GitHub voor %s is %s',
     'adding_new_build' => 'Laatste commit verschilt van database, nieuwe build wordt toegevoegd',
     'finished_processing_builds' => 'Verwerking builds voltooid.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Administrator-gebruiker aanmaken',

--- a/PHPCI/Languages/lang.pl.php
+++ b/PHPCI/Languages/lang.pl.php
@@ -330,6 +330,7 @@ Przejrzyj powyższą listę błędów przed kontynuowaniem.',
     'last_commit_is' => 'Ostatni commit do GitHuba dla %s to %s',
     'adding_new_build' => 'Ostatni commit jest inny w bazie danych, dodaję nową budowę.',
     'finished_processing_builds' => 'Ukończono przetwarzanie budów.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Utwórz admina',

--- a/PHPCI/Languages/lang.ru.php
+++ b/PHPCI/Languages/lang.ru.php
@@ -325,6 +325,7 @@ PHPCI',
     'last_commit_is' => 'Последний коммит на GitHub для %s - %s',
     'adding_new_build' => 'Последний коммит имеет различия с базой данных, создана сборка.',
     'finished_processing_builds' => 'Процесс сборки завершен.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Добавить аккаунт администратора',

--- a/PHPCI/Languages/lang.uk.php
+++ b/PHPCI/Languages/lang.uk.php
@@ -329,6 +329,7 @@ PHPCI',
     'last_commit_is' => 'Останній коміт на GitHub для %s - %s',
     'adding_new_build' => 'Останній коміт має відмінності із базою даних, створена нова збірка.',
     'finished_processing_builds' => 'Завершено обробку збірок.',
+    'build_cancelled' => 'Build cancelled', // TODO: Translate me
 
     // Create Admin
     'create_admin_user' => 'Створити аккаунт адміністратора',

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "psr/log": "~1.0",
         "monolog/monolog": "~1.6",
         "pimple/pimple": "~1.1",
-        "robmorgan/phinx": "~0.4"
+        "robmorgan/phinx": "~0.4",
+        "che/console-signals": "dev-master#6ffc5db7cbab1cc31957b6c3ee7e2c01f54503eb"
     },
 
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4ae188c6be1c1388de6271a3b0e0475d",
+    "hash": "bf17e23700ad2eefa8bf0bc89cb7cdbb",
     "packages": [
         {
             "name": "block8/b8framework",
@@ -52,6 +52,57 @@
                 "php"
             ],
             "time": "2014-12-01 21:02:58"
+        },
+        {
+            "name": "che/console-signals",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chEbba/ConsoleSignals.git",
+                "reference": "6ffc5db7cbab1cc31957b6c3ee7e2c01f54503eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chEbba/ConsoleSignals/zipball/6ffc5db7cbab1cc31957b6c3ee7e2c01f54503eb",
+                "reference": "6ffc5db7cbab1cc31957b6c3ee7e2c01f54503eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.1",
+                "symfony/console": "~2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*",
+                "symfony/console": "2.3.0",
+                "symfony/process": "2.3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Che\\ConsoleSignals\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kirill chEbba Chebunin",
+                    "email": "iam@chebba.org",
+                    "homepage": "http://github.com/chEbba"
+                }
+            ],
+            "description": "Unix signal support for Symfony Console",
+            "homepage": "http://github.com/chEbba/ConsoleSignals",
+            "keywords": [
+                "console",
+                "pcntl",
+                "process",
+                "restart",
+                "signal"
+            ],
+            "time": "2014-02-17 09:19:04"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -172,12 +223,12 @@
             "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fabpot/Pimple.git",
+                "url": "https://github.com/silexphp/Pimple.git",
                 "reference": "2019c145fe393923f3441b23f29bbdfaa5c58c4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fabpot/Pimple/zipball/2019c145fe393923f3441b23f29bbdfaa5c58c4d",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/2019c145fe393923f3441b23f29bbdfaa5c58c4d",
                 "reference": "2019c145fe393923f3441b23f29bbdfaa5c58c4d",
                 "shasum": ""
             },
@@ -202,9 +253,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
@@ -2028,8 +2077,11 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "che/console-signals": 20
+    },
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3.8",
         "ext-pdo": "*",


### PR DESCRIPTION
Contribution Type: cosmetic
Primary Area: builder

Description of change:
Cancelling the run command left a build set as "Running".

Description of solution:
This PR implements signal handling in Unix and will clean-up the status of a build in the event that a command is killed with a SIGINT (pressing ctrl + c) or a SIGTERM (something else telling the command to stop).

# TODO
- [ ] Translations, currently they have the English text there with a TODO, I cannot offer anymore translations
- [ ] The composer dependency is locked to a commit as there is no stable version tagged, I've asked the maintainer to tag a stable version.