### PR TITLE
Let CommandExecutor::findBinary throw an exception.

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -263,12 +263,14 @@ class Builder implements LoggerAwareInterface
 
     /**
      * Find a binary required by a plugin.
-     * @param $binary
+     * @param string $binary
+     * @param bool $quiet
+     *
      * @return null|string
      */
-    public function findBinary($binary)
+    public function findBinary($binary, $quiet = false)
     {
-        return $this->commandExecutor->findBinary($binary, $this->buildPath);
+        return $this->commandExecutor->findBinary($binary, $quiet = false);
     }
 
     /**

--- a/PHPCI/Helper/CommandExecutor.php
+++ b/PHPCI/Helper/CommandExecutor.php
@@ -26,10 +26,13 @@ interface CommandExecutor
     /**
      * Find a binary required by a plugin.
      * @param string $binary
-     * @param string $buildPath the current build path
+     * @param bool $quiet Returns null instead of throwing an execption.
+     *
      * @return null|string
+     *
+     * @throws \Exception when no binary has been found and $quiet is false.
      */
-    public function findBinary($binary, $buildPath = null);
+    public function findBinary($binary, $quiet = false);
 
     /**
      * Set the buildPath property.

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -133,12 +133,6 @@ class Codeception implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         } else {
             $codecept = $this->phpci->findBinary('codecept');
 
-            if (!$codecept) {
-                $this->phpci->logFailure(Lang::get('could_not_find', 'codecept'));
-
-                return false;
-            }
-
             $cmd = 'cd "%s" && ' . $codecept . ' run -c "%s" --tap ' . $this->args;
 
             if (IS_WIN) {

--- a/PHPCI/Plugin/Composer.php
+++ b/PHPCI/Plugin/Composer.php
@@ -81,11 +81,6 @@ class Composer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
     {
         $composerLocation = $this->phpci->findBinary(array('composer', 'composer.phar'));
 
-        if (!$composerLocation) {
-            $this->phpci->logFailure(Lang::get('could_not_find', 'composer'));
-            return false;
-        }
-
         $cmd = '';
 
         if (IS_WIN) {

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -79,15 +79,10 @@ class Pdepend implements \PHPCI\Plugin
 
         $pdepend = $this->phpci->findBinary('pdepend');
 
-        if (!$pdepend) {
-            $this->phpci->logFailure(Lang::get('could_not_find', 'pdepend'));
-            return false;
-        }
-
         $cmd = $pdepend . ' --summary-xml="%s" --jdepend-chart="%s" --overview-pyramid="%s" %s "%s"';
 
         $this->removeBuildArtifacts();
-       
+
         // If we need to ignore directories
         if (count($this->phpci->ignore)) {
             $ignore = ' --ignore=' . implode(',', $this->phpci->ignore);

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -81,11 +81,6 @@ class Phing implements \PHPCI\Plugin
     {
         $phingExecutable = $this->phpci->findBinary('phing');
 
-        if (!$phingExecutable) {
-            $this->phpci->logFailure(Lang::get('could_not_find', 'phing'));
-            return false;
-        }
-
         $cmd[] = $phingExecutable . ' -f ' . $this->getBuildFilePath();
 
         if ($this->getPropertyFile()) {

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -149,11 +149,6 @@ class PhpCodeSniffer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
         $phpcs = $this->phpci->findBinary('phpcs');
 
-        if (!$phpcs) {
-            $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpcs'));
-            return false;
-        }
-
         $this->phpci->logExecOutput(false);
 
         $cmd = $phpcs . ' --report=json %s %s %s %s %s "%s"';

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -90,18 +90,13 @@ class PhpCpd implements \PHPCI\Plugin
 
         $phpcpd = $this->phpci->findBinary('phpcpd');
 
-        if (!$phpcpd) {
-            $this->phpci->logFailure(Lang::get('could_not_find', 'phpcpd'));
-            return false;
-        }
-
         $tmpfilename = tempnam('/tmp', 'phpcpd');
 
         $cmd = $phpcpd . ' --log-pmd "%s" %s "%s"';
         $success = $this->phpci->executeCommand($cmd, $tmpfilename, $ignore, $this->path);
 
         print $this->phpci->getLastOutput();
-        
+
         list($errorCount, $data) = $this->processReport(file_get_contents($tmpfilename));
         $this->build->storeMeta('phpcpd-warnings', $errorCount);
         $this->build->storeMeta('phpcpd-data', $data);

--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -69,11 +69,6 @@ class PhpCsFixer implements \PHPCI\Plugin
 
         $phpcsfixer = $this->phpci->findBinary('php-cs-fixer');
 
-        if (!$phpcsfixer) {
-            $this->phpci->logFailure(Lang::get('could_not_find', 'php-cs-fixer'));
-            return false;
-        }
-
         $cmd = $phpcsfixer . ' fix . %s %s %s';
         $success = $this->phpci->executeCommand($cmd, $this->verbose, $this->diff, $this->level);
 

--- a/PHPCI/Plugin/PhpDocblockChecker.php
+++ b/PHPCI/Plugin/PhpDocblockChecker.php
@@ -104,11 +104,6 @@ class PhpDocblockChecker implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
         // Check that the binary exists:
         $checker = $this->phpci->findBinary('phpdoccheck');
 
-        if (!$checker) {
-            $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpdoccheck'));
-            return false;
-        }
-
         // Build ignore string:
         $ignore = '';
         if (count($this->ignore)) {

--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -80,11 +80,6 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
         $phploc = $this->phpci->findBinary('phploc');
 
-        if (!$phploc) {
-            $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phploc'));
-            return false;
-        }
-
         $success = $this->phpci->executeCommand($phploc . ' %s "%s"', $ignore, $this->directory);
         $output = $this->phpci->getLastOutput();
 

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -121,11 +121,6 @@ class PhpMessDetector implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
         $phpmdBinaryPath = $this->phpci->findBinary('phpmd');
 
-        if (!$phpmdBinaryPath) {
-            $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpmd'));
-            return false;
-        }
-
         $this->executePhpMd($phpmdBinaryPath);
 
         list($errorCount, $data) = $this->processReport(trim($this->phpci->getLastOutput()));

--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -78,11 +78,6 @@ class PhpParallelLint implements \PHPCI\Plugin
 
         $phplint = $this->phpci->findBinary('parallel-lint');
 
-        if (!$phplint) {
-            $this->phpci->logFailure(Lang::get('could_not_find', 'parallel-lint'));
-            return false;
-        }
-
         $cmd = $phplint . ' %s "%s"';
         $success = $this->phpci->executeCommand(
             $cmd,

--- a/PHPCI/Plugin/PhpSpec.php
+++ b/PHPCI/Plugin/PhpSpec.php
@@ -59,11 +59,6 @@ class PhpSpec implements PHPCI\Plugin
 
         $phpspec = $this->phpci->findBinary(array('phpspec', 'phpspec.php'));
 
-        if (!$phpspec) {
-            $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpspec'));
-            return false;
-        }
-
         $success = $this->phpci->executeCommand($phpspec . ' --format=junit --no-code-generation run');
         $output = $this->phpci->getLastOutput();
 

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -197,14 +197,7 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
                 chdir($this->phpci->buildPath.'/'.$this->runFrom);
             }
 
-
             $phpunit = $this->phpci->findBinary('phpunit');
-
-            if (!$phpunit) {
-                $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpunit'));
-                return false;
-            }
-
 
             $cmd = $phpunit . ' --tap %s -c "%s" ' . $this->coverage . $this->path;
             $success = $this->phpci->executeCommand($cmd, $this->args, $this->phpci->buildPath . $configPath);
@@ -231,11 +224,6 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
             chdir($this->phpci->buildPath);
 
             $phpunit = $this->phpci->findBinary('phpunit');
-
-            if (!$phpunit) {
-                $this->phpci->logFailure(PHPCI\Helper\Lang::get('could_not_find', 'phpunit'));
-                return false;
-            }
 
             $cmd = $phpunit . ' --tap %s "%s"';
             $success = $this->phpci->executeCommand($cmd, $this->args, $this->phpci->buildPath . $directory);

--- a/PHPCI/Plugin/Xmpp.php
+++ b/PHPCI/Plugin/Xmpp.php
@@ -148,12 +148,7 @@ class XMPP implements \PHPCI\Plugin
     */
     public function execute()
     {
-        $sendxmpp = $this->phpci->findBinary('/usr/bin/sendxmpp');
-
-        if (!$sendxmpp) {
-            $this->phpci->logFailure('Could not find sendxmpp.');
-            return false;
-        }
+        $sendxmpp = $this->phpci->findBinary('sendxmpp');
 
         /*
          * Without recipients we can't send notification

--- a/Tests/PHPCI/Helper/CommandExecutorTest.php
+++ b/Tests/PHPCI/Helper/CommandExecutorTest.php
@@ -16,7 +16,8 @@ class CommandExecutorTest extends ProphecyTestCase
     {
         parent::setUp();
         $mockBuildLogger = $this->prophesize('PHPCI\Logging\BuildLogger');
-        $this->testedExecutor = new UnixCommandExecutor($mockBuildLogger->reveal(), __DIR__ . "/");
+        $class = IS_WIN ? 'PHPCI\Helper\WindowsCommandExecutor' : 'PHPCI\Helper\UnixCommandExecutor';
+        $this->testedExecutor = new $class($mockBuildLogger->reveal(), __DIR__ . "/");
     }
 
     public function testGetLastOutput_ReturnsOutputOfCommand()
@@ -51,5 +52,21 @@ class CommandExecutorTest extends ProphecyTestCase
         $thisFileName = "CommandExecutorTest.php";
         $returnValue = $this->testedExecutor->findBinary($thisFileName);
         $this->assertEquals(__DIR__ . "/" . $thisFileName, $returnValue);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedMessageRegex WorldWidePeace
+     */
+    public function testFindBinary_ThrowsWhenNotFound()
+    {
+        $thisFileName = "WorldWidePeace";
+        $this->testedExecutor->findBinary($thisFileName);
+    }
+
+    public function testFindBinary_ReturnsNullWihQuietArgument()
+    {
+        $thisFileName = "WorldWidePeace";
+        $this->assertNull($this->testedExecutor->findBinary($thisFileName, true));
     }
 }


### PR DESCRIPTION
Since CommandExecutor::findBinary is followed by this piece of code in *all* plugins, I modified CommandExecutor::findBinary to throw an exception, unless the new optional argument $quiet yields true (in which case the method returns null, as before).

```
if(!$binary) {
    $this->phpci->logFailure(Lang::get('could_not_find', 'binary'));
    return false;
}
```