### PR TITLE
Configuration files for PHPMD & PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "phpunit/phpunit": "~4.0",
         "phpspec/prophecy-phpunit": "~1.0",
         "phpmd/phpmd": "~2.0",
-        "squizlabs/php_codesniffer": "~2.0",
+        "squizlabs/php_codesniffer": "~2.3",
         "block8/php-docblock-checker": "~1.0",
         "phploc/phploc": "~2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5fc23800ea77b50b496d34f7aa5cf6b3",
+    "hash": "a4a95f2b83e336b9e1b285c04af26ce7",
     "packages": [
         {
             "name": "block8/b8framework",
@@ -172,12 +172,12 @@
             "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fabpot/Pimple.git",
+                "url": "https://github.com/silexphp/Pimple.git",
                 "reference": "2019c145fe393923f3441b23f29bbdfaa5c58c4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fabpot/Pimple/zipball/2019c145fe393923f3441b23f29bbdfaa5c58c4d",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/2019c145fe393923f3441b23f29bbdfaa5c58c4d",
                 "reference": "2019c145fe393923f3441b23f29bbdfaa5c58c4d",
                 "shasum": ""
             },
@@ -202,9 +202,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
@@ -1856,20 +1854,21 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b301c98f19414d836fdaa678648745fcca5aeb4f"
+                "reference": "5046b0e01c416fc2b06df961d0673c85bcdc896c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b301c98f19414d836fdaa678648745fcca5aeb4f",
-                "reference": "b301c98f19414d836fdaa678648745fcca5aeb4f",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5046b0e01c416fc2b06df961d0673c85bcdc896c",
+                "reference": "5046b0e01c416fc2b06df961d0673c85bcdc896c",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
                 "php": ">=5.1.2"
             },
             "bin": [
@@ -1877,6 +1876,11 @@
                 "scripts/phpcbf"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "CodeSniffer.php",
@@ -1920,7 +1924,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2015-01-21 22:44:05"
+            "time": "2015-03-04 02:07:03"
         },
         {
             "name": "symfony/dependency-injection",

--- a/phpci.yml
+++ b/phpci.yml
@@ -17,8 +17,10 @@ setup:
 test:
   php_mess_detector:
     allowed_warnings: 0
+    rules:
+      - phpmd.xml
   php_code_sniffer:
-    standard: "PSR2"
+    standard: phpcs.xml
     allowed_warnings: 0
     allowed_errors: 0
   php_loc:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCI">
+
+    <description>Codestyle ruleset for PHPCI</description>
+
+    <rule ref="PSR2"/>
+
+    <file>PHPCI</file>
+
+    <arg name="encoding" value="UTF-8"/>
+    <arg name="extensions" value="php"/>
+
+    <exclude-pattern>PHPCI/Migrations/*</exclude-pattern>
+    <exclude-pattern>PHPCI/Model/Base/*</exclude-pattern>
+    <exclude-pattern>PHPCI/Languages/*</exclude-pattern>
+    <exclude-pattern>Tests/*</exclude-pattern>
+    <exclude-pattern>vendor/*</exclude-pattern>
+
+</ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCI"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                     http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="
+                     http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>
+        PHPCI rule set
+    </description>
+
+    <rule ref="rulesets/codesize.xml" />
+    <rule ref="rulesets/unusedcode.xml" />
+    <rule ref="rulesets/naming.xml" />
+
+</ruleset>


### PR DESCRIPTION
Simply added configuration files of PHPMD and PHPCS for PHPCI developpers. They contain the default settings used by phpci.yml. I also have a configuration file for fabpot/php-cs-fixer but I'm not sure it is interesting.