### PR TITLE
[WIP] Plugin cleanup

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -78,11 +78,6 @@ class Builder implements LoggerAwareInterface
     protected $store;
 
     /**
-     * @var bool
-     */
-    public $quiet = false;
-
-    /**
      * @var \PHPCI\Plugin\Util\Executor
      */
     protected $pluginExecutor;
@@ -121,7 +116,6 @@ class Builder implements LoggerAwareInterface
         $this->commandExecutor = new $executorClass(
             $this->buildLogger,
             PHPCI_DIR,
-            $this->quiet,
             $this->verbose
         );
 
@@ -237,7 +231,8 @@ class Builder implements LoggerAwareInterface
      */
     public function executeCommand()
     {
-        return $this->commandExecutor->executeCommand(func_get_args());
+        $args = func_get_args();
+        return call_user_func_array(array($this->commandExecutor, 'executeCommand'), $args);
     }
 
     /**
@@ -254,7 +249,7 @@ class Builder implements LoggerAwareInterface
      */
     public function logExecOutput($enableLog = true)
     {
-        $this->commandExecutor->logExecOutput = $enableLog;
+        $this->commandExecutor->setQuiet(!$enableLog);
     }
 
     /**
@@ -397,6 +392,14 @@ class Builder implements LoggerAwareInterface
             },
             'interpolator',
             'PHPCI\Helper\BuildInterpolator'
+        );
+
+        $pluginFactory->registerResource(
+            function () use ($self) {
+                return $self->commandExecutor;
+            },
+            'executor',
+            'PHPCI\Helper\CommandExecutor'
         );
 
         $pluginFactory->registerResource(

--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -400,6 +400,14 @@ class Builder implements LoggerAwareInterface
             'Swift_Mailer'
         );
 
+        $pluginFactory->registerResource(
+            function () use ($self) {
+                return $self->buildLogger;
+            },
+            null,
+            'PHPCI\Logging\BuildLogger'
+        );
+
         return $pluginFactory;
     }
 }

--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -393,6 +393,14 @@ class Builder implements LoggerAwareInterface
 
         $pluginFactory->registerResource(
             function () use ($self) {
+                return $self->interpolator;
+            },
+            'interpolator',
+            'PHPCI\Helper\BuildInterpolator'
+        );
+
+        $pluginFactory->registerResource(
+            function () use ($self) {
                 $factory = new MailerFactory($self->getSystemConfig('phpci'));
                 return $factory->getSwiftMailerFromConfig();
             },

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -27,7 +27,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
     /**
      * @var bool
      */
-    protected $quiet;
+    protected $quiet = false;
 
     /**
      * @var bool
@@ -36,8 +36,6 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
     protected $lastOutput;
     protected $lastError;
-
-    public $logExecOutput = true;
 
     /**
      * The path which findBinary will look in.
@@ -57,10 +55,9 @@ abstract class BaseCommandExecutor implements CommandExecutor
      * @param bool        $quiet
      * @param bool        $verbose
      */
-    public function __construct(BuildLogger $logger, $rootDir, &$quiet = false, &$verbose = false)
+    public function __construct(BuildLogger $logger, $rootDir, &$verbose = false)
     {
         $this->logger = $logger;
-        $this->quiet = $quiet;
         $this->verbose = $verbose;
         $this->lastOutput = array();
         $this->rootDir = $rootDir;
@@ -68,13 +65,15 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
     /**
      * Executes shell commands.
-     * @param array $args
+     * @param string $arg1
+     * @param string ...
      * @return bool Indicates success
      */
-    public function executeCommand($args = array())
+    public function executeCommand()
     {
         $this->lastOutput = array();
 
+        $args = func_get_args();
         $command = call_user_func_array('sprintf', $args);
 
         if ($this->quiet) {
@@ -106,7 +105,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
         $this->lastOutput = array_filter(explode(PHP_EOL, $this->lastOutput));
 
-        $shouldOutput = ($this->logExecOutput && ($this->verbose || $status != 0));
+        $shouldOutput = !$this->quiet && ($this->verbose || $status != 0);
 
         if ($shouldOutput && !empty($this->lastOutput)) {
             $this->logger->log($this->lastOutput);

--- a/PHPCI/Helper/CommandExecutor.php
+++ b/PHPCI/Helper/CommandExecutor.php
@@ -14,6 +14,8 @@ interface CommandExecutor
     /**
      * Executes shell commands. Accepts multiple arguments the first
      * is the template and everything else is inserted in. c.f. sprintf
+     * @param string $arg1
+     * @param string ...
      * @return bool Indicates success
      */
     public function executeCommand();

--- a/PHPCI/Plugin.php
+++ b/PHPCI/Plugin.php
@@ -15,5 +15,29 @@ namespace PHPCI;
 */
 interface Plugin
 {
+    /**
+     * Sets the options for the current build stage.
+     *
+     * @param array $options
+     *
+     * @throws \Exception If the options are invalid.
+     */
+    public function setOptions(array $options);
+
+    /**
+     * Sets the settings for all stages.
+     *
+     * @param array $settings
+     *
+     * @throws \Exception If the settings are invalid.
+     */
+    public function setCommonSettings(array $settings);
+
+    /**
+     * Execute the plugin.
+     *
+     * @return bool true if all went nice, false if the plugin ended normally but failed.
+     * @throws \Exception If something prevented the plugin to end normally.
+     */
     public function execute();
 }

--- a/PHPCI/Plugin/AbstractExecutingPlugin.php
+++ b/PHPCI/Plugin/AbstractExecutingPlugin.php
@@ -12,38 +12,39 @@
 namespace PHPCI\Plugin;
 
 use PHPCI\Builder;
-use PHPCI\Helper\BuildInterpolator;
 use PHPCI\Helper\CommandExecutor;
+use PHPCI\Logging\BuildLogger;
 use PHPCI\Model\Build;
 
 /**
- * Asbtract plugin which uses a BuildInterpolator.
+ * Asbtract plugin that executes commands.
+ *
+ * Holds helper for the subclasses.
  */
-abstract class AbstractInterpolatingPlugin extends AbstractExecutingPlugin
+abstract class AbstractExecutingPlugin extends AbstractPlugin
 {
     /**
-     * @var BuildInterpolator
+     * @var CommandExecutor
      */
-    protected $interpolator;
+    protected $executor;
 
-    /** Standard constructor.
+    /**
+     * Setup and configure the plugin.
      *
-     * @param Builder $phpci
-     * @param Build $build
+     * @param Builder $builder
+     * @param Build   $build
      * @param BuildLogger $logger
      * @param CommandExecutor $executor
-     * @param BuildInterpolator $interpolator
-     * @param array $options
+     * @param array   $options
      */
     public function __construct(
-        Builder $phpci,
+        Builder $builder,
         Build $build,
         BuildLogger $logger,
         CommandExecutor $executor,
-        BuildInterpolator $interpolator,
         array $options = array()
     ) {
-        $this->interpolator = $interpolator;
-        parent::__construct($phpci, $build, $logger, $executor, $options);
+        $this->executor = $executor;
+        parent:__construct($builder, $build, $logger, $options);
     }
 }

--- a/PHPCI/Plugin/AbstractExecutingPlugin.php
+++ b/PHPCI/Plugin/AbstractExecutingPlugin.php
@@ -33,18 +33,14 @@ abstract class AbstractExecutingPlugin extends AbstractPlugin
      *
      * @param Builder $builder
      * @param Build   $build
-     * @param BuildLogger $logger
      * @param CommandExecutor $executor
-     * @param array   $options
      */
     public function __construct(
         Builder $builder,
         Build $build,
-        BuildLogger $logger,
-        CommandExecutor $executor,
-        array $options = array()
+        CommandExecutor $executor
     ) {
         $this->executor = $executor;
-        parent:__construct($builder, $build, $logger, $options);
+        parent:__construct($builder, $build);
     }
 }

--- a/PHPCI/Plugin/AbstractInterpolatingPlugin.php
+++ b/PHPCI/Plugin/AbstractInterpolatingPlugin.php
@@ -11,39 +11,25 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\BuildInterpolator;
-use PHPCI\Helper\CommandExecutor;
-use PHPCI\Model\Build;
+use PHPCI\Plugin\Util\InterpolatorAwareInterface;
 
 /**
  * Asbtract plugin which uses a BuildInterpolator.
  */
-abstract class AbstractInterpolatingPlugin extends AbstractExecutingPlugin
+abstract class AbstractInterpolatingPlugin extends AbstractExecutingPlugin implements InterpolatorAwareInterface
 {
     /**
      * @var BuildInterpolator
      */
     protected $interpolator;
 
-    /** Standard constructor.
+    /**
      *
-     * @param Builder $phpci
-     * @param Build $build
-     * @param BuildLogger $logger
-     * @param CommandExecutor $executor
      * @param BuildInterpolator $interpolator
-     * @param array $options
      */
-    public function __construct(
-        Builder $phpci,
-        Build $build,
-        BuildLogger $logger,
-        CommandExecutor $executor,
-        BuildInterpolator $interpolator,
-        array $options = array()
-    ) {
+    public function setInterpolator(BuildInterpolator $interpolator)
+    {
         $this->interpolator = $interpolator;
-        parent::__construct($phpci, $build, $logger, $executor, $options);
     }
 }

--- a/PHPCI/Plugin/AbstractInterpolatingPlugin.php
+++ b/PHPCI/Plugin/AbstractInterpolatingPlugin.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * PHPCI - Continuous Integration for PHP.
+ *
+ * @copyright    Copyright 2015, Block 8 Limited.
+ * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ *
+ * @link         https://www.phptesting.org/
+ */
+
+namespace PHPCI\Plugin;
+
+use PHPCI\Builder;
+use PHPCI\Helper\BuildInterpolator;
+use PHPCI\Model\Build;
+use PHPCI\Plugin\AbstractPlugin;
+
+/**
+ * Asbtract plugin which uses a BuildInterpolator.
+ */
+abstract class AbstractInterpolatingPlugin extends AbstractPlugin
+{
+    /**
+     * @var BuildInterpolator
+     */
+    protected $interpolator;
+
+    /** Standard constructor.
+     *
+     * @param Builder $phpci
+     * @param Build $build
+     * @param BuildInterpolator $interpolator
+     */
+    public function __construct(Builder $phpci, Build $build, BuildInterpolator $interpolator)
+    {
+        $this->interpolator = $interpolator;
+        parent::__construct($phpci, $build);
+    }
+}

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -93,6 +93,8 @@ abstract class AbstractPlugin implements Plugin
      * Configure the plugin with the common settings.
      *
      * @param array $settings
+     *
+     * @SuppressWarnings(unused)
      */
     protected function setCommonSettings(array $settings)
     {

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -49,7 +49,6 @@ abstract class AbstractPlugin implements Plugin
     {
         $this->phpci = $builder;
         $this->build = $build;
-        $this->buildPath = $builder->buildPath;
         $this->logger = $logger;
 
         $this->setup($options);
@@ -71,6 +70,15 @@ abstract class AbstractPlugin implements Plugin
     }
 
     /**
+     * Set the build path.
+     *
+     * @param string $buildPath
+     */
+    protected function setBuildPath($buildPath)
+    {
+        $this->buildPath = $buildPath;
+    }
+
      * Configure the plugin with the common settings.
      *
      * @param array $settings
@@ -96,6 +104,8 @@ abstract class AbstractPlugin implements Plugin
      */
     private function setup(array $options)
     {
+        $this->setBuildPath($this->phpci->buildPath);
+
         $settings = $this->phpci->getConfig('build_settings');
         $key = $this->getPluginKey();
         if ($settings && isset($settings[$key])) {

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -14,13 +14,15 @@ use PHPCI\Builder;
 use PHPCI\Logging\BuildLogger;
 use PHPCI\Model\Build;
 use PHPCI\Plugin;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Asbtract plugin.
  *
  * Holds helper for the subclasses.
  */
-abstract class AbstractPlugin implements Plugin
+abstract class AbstractPlugin implements Plugin, LoggerAwareInterface
 {
     /**
      * @var Build
@@ -33,7 +35,7 @@ abstract class AbstractPlugin implements Plugin
     protected $phpci;
 
     /**
-     * @var BuildLogger
+     * @var LoggerInterface
      */
     protected $logger;
 
@@ -43,30 +45,23 @@ abstract class AbstractPlugin implements Plugin
      * @param Builder $builder
      * @param Build   $build
      * @param BuildLogger $logger
-     * @param array   $options
      */
-    public function __construct(Builder $builder, Build $build, BuildLogger $logger, array $options = array())
+    public function __construct(Builder $builder, Build $build)
     {
         $this->phpci = $builder;
         $this->build = $build;
-        $this->logger = $logger;
 
-        $this->setup($options);
+        $this->setBuildPath($builder->buildPath);
+        $this->setIgnorePath((array) $builder->ignore);
     }
 
     /**
-     * Return the key used for options in phpci.yml for this plugin.
      *
-     * @return string
+     * @param LoggerInterface $logger
      */
-    public function getPluginKey()
+    public function setLogger(LoggerInterface $logger)
     {
-        $matches = null;
-        $className = get_class($this);
-        if (!preg_match('/^PHPCI\\Plguin\\(\w+)$/', $className, $matches)) {
-            return $className;
-        }
-        return strtolower(preg_replace('/[[:lower:]][[:upper:]]/g', '$1_$2', $matches[1]));
+        $this->logger = $logger;
     }
 
     /**
@@ -99,35 +94,5 @@ abstract class AbstractPlugin implements Plugin
     protected function setCommonSettings(array $settings)
     {
         // NOOP
-    }
-
-    /**
-     * Configure the plugin for a given stage.
-     *
-     * @param array $options
-     */
-    abstract protected function setOptions(array $options);
-
-    /**
-     * Post-constructor setup.
-     *
-     * TODO: expose setOptions and setCommonSettings in Plugin and get rid of this method.
-     *
-     * @param array $options
-     */
-    private function setup(array $options)
-    {
-        $this->setBuildPath($this->phpci->buildPath);
-        $this->setIgnorePath((array) $this->phpci->ignore);
-
-        $settings = $this->phpci->getConfig('build_settings');
-        $key = $this->getPluginKey();
-        if ($settings && isset($settings[$key])) {
-            $this->setCommonSettings((array) $settings[$key]);
-        } else {
-            $this->setCommonSettings(array());
-        }
-
-        $this->setOptions($options);
     }
 }

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -11,6 +11,7 @@
 namespace PHPCI\Plugin;
 
 use PHPCI\Builder;
+use PHPCI\Logging\BuildLogger;
 use PHPCI\Model\Build;
 use PHPCI\Plugin;
 
@@ -32,17 +33,24 @@ abstract class AbstractPlugin implements Plugin
     protected $phpci;
 
     /**
+     * @var BuildLogger
+     */
+    protected $logger;
+
+    /**
      * Setup and configure the plugin.
      *
      * @param Builder $builder
      * @param Build   $build
+     * @param BuildLogger $logger
      * @param array   $options
      */
-    public function __construct(Builder $builder, Build $build, array $options = array())
+    public function __construct(Builder $builder, Build $build, BuildLogger $logger, array $options = array())
     {
         $this->phpci = $builder;
         $this->build = $build;
         $this->buildPath = $builder->buildPath;
+        $this->logger = $logger;
 
         $this->setOptions($options);
     }

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -42,6 +42,7 @@ abstract class AbstractPlugin implements Plugin
     {
         $this->phpci = $builder;
         $this->build = $build;
+        $this->buildPath = $builder->buildPath;
 
         $this->setOptions($options);
     }

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -32,12 +32,24 @@ abstract class AbstractPlugin implements Plugin
     protected $phpci;
 
     /**
-     * @param Builder $phpci
+     * Setup and configure the plugin.
+     *
+     * @param Builder $builder
      * @param Build   $build
+     * @param array   $options
      */
-    public function __construct(Builder $phpci, Build $build)
+    public function __construct(Builder $builder, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
+        $this->phpci = $builder;
         $this->build = $build;
+
+        $this->setOptions($options);
     }
+
+    /**
+     * Configure the plugin.
+     *
+     * @param array $options
+     */
+    abstract protected function setOptions(array $options);
 }

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -79,6 +79,17 @@ abstract class AbstractPlugin implements Plugin
         $this->buildPath = $buildPath;
     }
 
+    /**
+     * Set the paths to ignore.
+     *
+     * @param string[] $paths
+     */
+    protected function setIgnorePaths(array $paths)
+    {
+        $this->ignore = $paths;
+    }
+
+    /**
      * Configure the plugin with the common settings.
      *
      * @param array $settings
@@ -105,6 +116,7 @@ abstract class AbstractPlugin implements Plugin
     private function setup(array $options)
     {
         $this->setBuildPath($this->phpci->buildPath);
+        $this->setIgnorePath((array) $this->phpci->ignore);
 
         $settings = $this->phpci->getConfig('build_settings');
         $key = $this->getPluginKey();

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCI - Continuous Integration for PHP.
+ *
+ * @copyright    Copyright 2015, Block 8 Limited.
+ * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ *
+ * @link         https://www.phptesting.org/
+ */
+
+namespace PHPCI\Plugin;
+
+use PHPCI\Builder;
+use PHPCI\Model\Build;
+use PHPCI\Plugin;
+
+/**
+ * Asbtract plugin.
+ *
+ * Holds helper for the subclasses.
+ */
+abstract class AbstractPlugin implements Plugin
+{
+    /**
+     * @var Build
+     */
+    protected $build;
+
+    /**
+     * @var Builder
+     */
+    protected $phpci;
+
+    /**
+     * @param Builder $phpci
+     * @param Build   $build
+     */
+    public function __construct(Builder $phpci, Build $build)
+    {
+        $this->phpci = $phpci;
+        $this->build = $build;
+    }
+}

--- a/PHPCI/Plugin/AbstractPlugin.php
+++ b/PHPCI/Plugin/AbstractPlugin.php
@@ -52,13 +52,58 @@ abstract class AbstractPlugin implements Plugin
         $this->buildPath = $builder->buildPath;
         $this->logger = $logger;
 
-        $this->setOptions($options);
+        $this->setup($options);
     }
 
     /**
-     * Configure the plugin.
+     * Return the key used for options in phpci.yml for this plugin.
+     *
+     * @return string
+     */
+    public function getPluginKey()
+    {
+        $matches = null;
+        $className = get_class($this);
+        if (!preg_match('/^PHPCI\\Plguin\\(\w+)$/', $className, $matches)) {
+            return $className;
+        }
+        return strtolower(preg_replace('/[[:lower:]][[:upper:]]/g', '$1_$2', $matches[1]));
+    }
+
+    /**
+     * Configure the plugin with the common settings.
+     *
+     * @param array $settings
+     */
+    protected function setCommonSettings(array $settings)
+    {
+        // NOOP
+    }
+
+    /**
+     * Configure the plugin for a given stage.
      *
      * @param array $options
      */
     abstract protected function setOptions(array $options);
+
+    /**
+     * Post-constructor setup.
+     *
+     * TODO: expose setOptions and setCommonSettings in Plugin and get rid of this method.
+     *
+     * @param array $options
+     */
+    private function setup(array $options)
+    {
+        $settings = $this->phpci->getConfig('build_settings');
+        $key = $this->getPluginKey();
+        if ($settings && isset($settings[$key])) {
+            $this->setCommonSettings((array) $settings[$key]);
+        } else {
+            $this->setCommonSettings(array());
+        }
+
+        $this->setOptions($options);
+    }
 }

--- a/PHPCI/Plugin/Atoum.php
+++ b/PHPCI/Plugin/Atoum.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * Atoum plugin, runs Atoum tests within a project.
@@ -24,15 +22,12 @@ class Atoum extends AbstractPlugin
     private $directory;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         if (isset($options['executable'])) {
             $this->executable = $this->phpci->buildPath . DIRECTORY_SEPARATOR.$options['executable'];
         } else {

--- a/PHPCI/Plugin/Atoum.php
+++ b/PHPCI/Plugin/Atoum.php
@@ -29,7 +29,7 @@ class Atoum extends AbstractPlugin
     protected function setOptions(array $options)
     {
         if (isset($options['executable'])) {
-            $this->executable = $this->phpci->buildPath . DIRECTORY_SEPARATOR.$options['executable'];
+            $this->executable = $this->buildPath . DIRECTORY_SEPARATOR.$options['executable'];
         } else {
             $this->executable = $this->phpci->findBinary('atoum');
         }
@@ -62,10 +62,10 @@ class Atoum extends AbstractPlugin
             $cmd .= " -c '{$this->config}'";
         }
         if ($this->directory !== null) {
-            $dirPath = $this->phpci->buildPath . DIRECTORY_SEPARATOR . $this->directory;
+            $dirPath = $this->buildPath . DIRECTORY_SEPARATOR . $this->directory;
             $cmd .= " -d '{$dirPath}'";
         }
-        chdir($this->phpci->buildPath);
+        chdir($this->buildPath);
         $output = '';
         $status = true;
         exec($cmd, $output);

--- a/PHPCI/Plugin/Atoum.php
+++ b/PHPCI/Plugin/Atoum.php
@@ -72,11 +72,11 @@ class Atoum extends AbstractPlugin
 
         if (count(preg_grep("/Success \(/", $output)) == 0) {
             $status = false;
-            $this->phpci->log($output);
+            $this->logger->log($output);
         }
         if (count($output) == 0) {
             $status = false;
-            $this->phpci->log(Lang::get('no_tests_performed'));
+            $this->logger->log(Lang::get('no_tests_performed'));
         }
 
         return $status;

--- a/PHPCI/Plugin/Atoum.php
+++ b/PHPCI/Plugin/Atoum.php
@@ -72,11 +72,11 @@ class Atoum extends AbstractExecutingPlugin
 
         if (count(preg_grep("/Success \(/", $output)) == 0) {
             $status = false;
-            $this->logger->log($output);
+            $this->logger->notice($output);
         }
         if (count($output) == 0) {
             $status = false;
-            $this->logger->log(Lang::get('no_tests_performed'));
+            $this->logger->warning(Lang::get('no_tests_performed'));
         }
 
         return $status;

--- a/PHPCI/Plugin/Atoum.php
+++ b/PHPCI/Plugin/Atoum.php
@@ -15,7 +15,7 @@ use PHPCI\Helper\Lang;
  * Atoum plugin, runs Atoum tests within a project.
  * @package PHPCI\Plugin
  */
-class Atoum extends AbstractPlugin
+class Atoum extends AbstractExecutingPlugin
 {
     private $args;
     private $config;
@@ -31,7 +31,7 @@ class Atoum extends AbstractPlugin
         if (isset($options['executable'])) {
             $this->executable = $this->buildPath . DIRECTORY_SEPARATOR.$options['executable'];
         } else {
-            $this->executable = $this->phpci->findBinary('atoum');
+            $this->executable = $this->executor->findBinary('atoum');
         }
 
         if (isset($options['args'])) {

--- a/PHPCI/Plugin/Atoum.php
+++ b/PHPCI/Plugin/Atoum.php
@@ -17,7 +17,7 @@ use PHPCI\Model\Build;
  * Atoum plugin, runs Atoum tests within a project.
  * @package PHPCI\Plugin
  */
-class Atoum implements \PHPCI\Plugin
+class Atoum extends AbstractPlugin
 {
     private $args;
     private $config;
@@ -31,8 +31,7 @@ class Atoum implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         if (isset($options['executable'])) {
             $this->executable = $this->phpci->buildPath . DIRECTORY_SEPARATOR.$options['executable'];
@@ -84,7 +83,7 @@ class Atoum implements \PHPCI\Plugin
             $status = false;
             $this->phpci->log(Lang::get('no_tests_performed'));
         }
-        
+
         return $status;
     }
 }

--- a/PHPCI/Plugin/Behat.php
+++ b/PHPCI/Plugin/Behat.php
@@ -47,7 +47,7 @@ class Behat extends AbstractPlugin
     public function execute()
     {
         $curdir = getcwd();
-        chdir($this->phpci->buildPath);
+        chdir($this->buildPath);
 
         $behat = $this->executable;
 

--- a/PHPCI/Plugin/Behat.php
+++ b/PHPCI/Plugin/Behat.php
@@ -52,9 +52,7 @@ class Behat extends AbstractPlugin
         $behat = $this->executable;
 
         if (!$behat) {
-            $this->phpci->logFailure(Lang::get('could_not_find', 'behat'));
-
-            return false;
+            throw new \RuntimeException(Lang::get('could_not_find', 'behat'));
         }
 
         $success = $this->phpci->executeCommand($behat . ' %s', $this->features);

--- a/PHPCI/Plugin/Behat.php
+++ b/PHPCI/Plugin/Behat.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * Behat BDD Plugin
@@ -24,21 +22,12 @@ class Behat extends AbstractPlugin
     protected $features;
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->features = '';
 
         if (isset($options['executable'])) {

--- a/PHPCI/Plugin/Behat.php
+++ b/PHPCI/Plugin/Behat.php
@@ -33,7 +33,7 @@ class Behat extends AbstractPlugin
         if (isset($options['executable'])) {
             $this->executable = $options['executable'];
         } else {
-            $this->executable = $this->phpci->findBinary('behat');
+            $this->executable = $this->executor->findBinary('behat');
         }
 
         if (!empty($options['features'])) {
@@ -55,7 +55,7 @@ class Behat extends AbstractPlugin
             throw new \RuntimeException(Lang::get('could_not_find', 'behat'));
         }
 
-        $success = $this->phpci->executeCommand($behat . ' %s', $this->features);
+        $success = $this->executor->executeCommand($behat . ' %s', $this->features);
         chdir($curdir);
 
         list($errorCount, $data) = $this->parseBehatOutput();
@@ -73,7 +73,7 @@ class Behat extends AbstractPlugin
      */
     public function parseBehatOutput()
     {
-        $output = $this->phpci->getLastOutput();
+        $output = $this->executor->getLastOutput();
 
         $parts = explode('---', $output);
 

--- a/PHPCI/Plugin/Behat.php
+++ b/PHPCI/Plugin/Behat.php
@@ -19,10 +19,8 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Behat implements \PHPCI\Plugin
+class Behat extends AbstractPlugin
 {
-    protected $phpci;
-    protected $build;
     protected $features;
 
     /**
@@ -39,8 +37,8 @@ class Behat implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci    = $phpci;
-        $this->build    = $build;
+        parent::__construct($phpci, $build);
+
         $this->features = '';
 
         if (isset($options['executable'])) {

--- a/PHPCI/Plugin/Campfire.php
+++ b/PHPCI/Plugin/Campfire.php
@@ -54,7 +54,6 @@ class Campfire implements \PHPCI\Plugin
         } else {
             throw new \Exception(Lang::get('no_campfire_settings'));
         }
-
     }
 
     /**
@@ -70,7 +69,6 @@ class Campfire implements \PHPCI\Plugin
         $this->leaveRoom($this->roomId);
 
         return $status;
-
     }
 
     /**
@@ -108,7 +106,6 @@ class Campfire implements \PHPCI\Plugin
         }
 
         return $this->getPageByPost($page, array('message' => array('type' => $type, 'body' => $message)));
-
     }
 
     /**

--- a/PHPCI/Plugin/Campfire.php
+++ b/PHPCI/Plugin/Campfire.php
@@ -38,7 +38,7 @@ class Campfire extends AbstractPlugin
         $this->userAgent = "PHPCI/1.0 (+http://www.phptesting.org/)";
         $this->cookie = "phpcicookie";
 
-        $buildSettings = $phpci->getConfig('build_settings');
+        $buildSettings = $this->phpci->getConfig('build_settings');
         if (isset($buildSettings['campfire'])) {
             $campfire = $buildSettings['campfire'];
             $this->url = $campfire['url'];

--- a/PHPCI/Plugin/Campfire.php
+++ b/PHPCI/Plugin/Campfire.php
@@ -20,7 +20,7 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Campfire implements \PHPCI\Plugin
+class Campfire extends AbstractPlugin
 {
     private $url;
     private $authToken;
@@ -38,8 +38,7 @@ class Campfire implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         $this->message = $options['message'];
         $this->userAgent = "PHPCI/1.0 (+http://www.phptesting.org/)";

--- a/PHPCI/Plugin/Campfire.php
+++ b/PHPCI/Plugin/Campfire.php
@@ -22,8 +22,8 @@ class Campfire extends AbstractPlugin
 {
     private $url;
     private $authToken;
-    private $userAgent;
-    private $cookie;
+    private $userAgent = "PHPCI/1.0 (+http://www.phptesting.org/)";
+    private $cookie = "phpcicookie";
     private $verbose;
     private $roomId;
 
@@ -35,18 +35,22 @@ class Campfire extends AbstractPlugin
     protected function setOptions(array $options)
     {
         $this->message = $options['message'];
-        $this->userAgent = "PHPCI/1.0 (+http://www.phptesting.org/)";
-        $this->cookie = "phpcicookie";
+    }
 
-        $buildSettings = $this->phpci->getConfig('build_settings');
-        if (isset($buildSettings['campfire'])) {
-            $campfire = $buildSettings['campfire'];
-            $this->url = $campfire['url'];
-            $this->authToken = $campfire['authToken'];
-            $this->roomId = $campfire['roomId'];
-        } else {
+    /**
+     * {@inheritdoc}
+     */
+    protected function setCommonSettings(array $settings)
+    {
+        parent::setCommonSettings($settings);
+
+        if(!isset($settings['url'], $settings['authToken'], $settings['roomId'])) {
             throw new \Exception(Lang::get('no_campfire_settings'));
         }
+
+        $this->url = $settings['url'];
+        $this->authToken = $settings['authToken'];
+        $this->roomId = $settings['roomId'];
     }
 
     /**

--- a/PHPCI/Plugin/Campfire.php
+++ b/PHPCI/Plugin/Campfire.php
@@ -44,7 +44,7 @@ class Campfire extends AbstractPlugin
     {
         parent::setCommonSettings($settings);
 
-        if(!isset($settings['url'], $settings['authToken'], $settings['roomId'])) {
+        if (!isset($settings['url'], $settings['authToken'], $settings['roomId'])) {
             throw new \Exception(Lang::get('no_campfire_settings'));
         }
 

--- a/PHPCI/Plugin/Campfire.php
+++ b/PHPCI/Plugin/Campfire.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * Campfire Plugin - Allows Campfire API actions.
@@ -30,16 +28,12 @@ class Campfire extends AbstractPlugin
     private $roomId;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
-     * @throws \Exception
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->message = $options['message'];
         $this->userAgent = "PHPCI/1.0 (+http://www.phptesting.org/)";
         $this->cookie = "phpcicookie";

--- a/PHPCI/Plugin/CleanBuild.php
+++ b/PHPCI/Plugin/CleanBuild.php
@@ -45,13 +45,13 @@ class CleanBuild extends AbstractPlugin
         if (IS_WIN) {
             $cmd = 'rmdir /S /Q "%s"';
         }
-        $this->phpci->executeCommand($cmd, $this->phpci->buildPath . 'composer.phar');
-        $this->phpci->executeCommand($cmd, $this->phpci->buildPath . 'composer.lock');
+        $this->phpci->executeCommand($cmd, $this->buildPath . 'composer.phar');
+        $this->phpci->executeCommand($cmd, $this->buildPath . 'composer.lock');
 
         $success = true;
 
         foreach ($this->remove as $file) {
-            $ok = $this->phpci->executeCommand($cmd, $this->phpci->buildPath . $file);
+            $ok = $this->phpci->executeCommand($cmd, $this->buildPath . $file);
 
             if (!$ok) {
                 $success = false;

--- a/PHPCI/Plugin/CleanBuild.php
+++ b/PHPCI/Plugin/CleanBuild.php
@@ -9,9 +9,6 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
-use PHPCI\Model\Build;
-
 /**
 * Clean build removes Composer related files and allows PHPCI users to clean up their build directory.
 * Useful as a precursor to copy_build.
@@ -30,16 +27,13 @@ class CleanBuild extends AbstractPlugin
      * $options['filename']  Phar Filename. Default: build.phar
      * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
      * $options['stub']      Stub Content. No Default Value
+     * Configure the plugin.
      *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $this->remove       = isset($options['remove']) && is_array($options['remove']) ? $options['remove'] : array();
+        $this->remove = isset($options['remove']) && is_array($options['remove']) ? $options['remove'] : array();
     }
 
     /**

--- a/PHPCI/Plugin/CleanBuild.php
+++ b/PHPCI/Plugin/CleanBuild.php
@@ -16,7 +16,7 @@ namespace PHPCI\Plugin;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class CleanBuild extends AbstractPlugin
+class CleanBuild extends AbstractExecutingPlugin
 {
     protected $remove;
 
@@ -45,13 +45,13 @@ class CleanBuild extends AbstractPlugin
         if (IS_WIN) {
             $cmd = 'rmdir /S /Q "%s"';
         }
-        $this->phpci->executeCommand($cmd, $this->buildPath . 'composer.phar');
-        $this->phpci->executeCommand($cmd, $this->buildPath . 'composer.lock');
+        $this->executor->executeCommand($cmd, $this->buildPath . 'composer.phar');
+        $this->executor->executeCommand($cmd, $this->buildPath . 'composer.lock');
 
         $success = true;
 
         foreach ($this->remove as $file) {
-            $ok = $this->phpci->executeCommand($cmd, $this->buildPath . $file);
+            $ok = $this->executor->executeCommand($cmd, $this->buildPath . $file);
 
             if (!$ok) {
                 $success = false;

--- a/PHPCI/Plugin/CleanBuild.php
+++ b/PHPCI/Plugin/CleanBuild.php
@@ -19,11 +19,9 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class CleanBuild implements \PHPCI\Plugin
+class CleanBuild extends AbstractPlugin
 {
     protected $remove;
-    protected $phpci;
-    protected $build;
 
     /**
      * Standard Constructor
@@ -39,8 +37,8 @@ class CleanBuild implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci        = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->remove       = isset($options['remove']) && is_array($options['remove']) ? $options['remove'] : array();
     }
 
@@ -57,7 +55,7 @@ class CleanBuild implements \PHPCI\Plugin
         $this->phpci->executeCommand($cmd, $this->phpci->buildPath . 'composer.lock');
 
         $success = true;
-        
+
         foreach ($this->remove as $file) {
             $ok = $this->phpci->executeCommand($cmd, $this->phpci->buildPath . $file);
 

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -116,7 +116,7 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         if (is_array($configPath)) {
             return $this->recurseArg($configPath, array($this, 'runConfigFile'));
         } else {
-            $this->phpci->logExecOutput(false);
+            $this->logger->logExecOutput(false);
 
             $codecept = $this->phpci->findBinary('codecept');
 
@@ -129,7 +129,7 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $configPath = $this->buildPath . $configPath;
             $success = $this->phpci->executeCommand($cmd, $this->buildPath, $configPath);
 
-            $this->phpci->log(
+            $this->logger->log(
                 'Codeception XML path: '. $this->buildPath . $this->path . '_output/report.xml',
                 Loglevel::DEBUG
             );
@@ -148,7 +148,7 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $this->build->storeMeta('codeception-data', $output);
             $this->build->storeMeta('codeception-errors', $parser->getTotalFailures());
 
-            $this->phpci->logExecOutput(true);
+            $this->logger->logExecOutput(true);
 
             return $success;
         }

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -129,10 +129,7 @@ class Codeception extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlu
             $configPath = $this->buildPath . $configPath;
             $success = $this->executor->executeCommand($cmd, $this->buildPath, $configPath);
 
-            $this->logger->log(
-                'Codeception XML path: '. $this->buildPath . $this->path . '_output/report.xml',
-                Loglevel::DEBUG
-            );
+            $this->logger->debug('Codeception XML path: '. $this->buildPath . $this->path . '_output/report.xml');
             $xml = file_get_contents($this->buildPath . $this->path . '_output/report.xml', false);
 
             $parser = new Parser($this->phpci, $xml);

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -73,21 +73,16 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     }
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
         $this->path = 'tests/';
 
         if (empty($options['config'])) {
             $this->ymlConfigFile = self::findConfigFile($this->phpci->buildPath);
-        }
-        if (isset($options['config'])) {
-            $this->ymlConfigFile = $options['config'];
         }
         if (isset($options['args'])) {
             $this->args = (string) $options['args'];

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -98,16 +98,11 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     public function execute()
     {
         if (empty($this->ymlConfigFile)) {
-            $this->phpci->logFailure('No configuration file found');
-            return false;
+            throw new \Exception("No configuration file found");
         }
 
-        $success = true;
-
         // Run any config files first. This can be either a single value or an array.
-        $success &= $this->runConfigFile($this->ymlConfigFile);
-
-        return $success;
+        return $this->runConfigFile($this->ymlConfigFile);
     }
 
     /**
@@ -131,22 +126,17 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
                 $cmd = 'cd /d "%s" && ' . $codecept . ' run -c "%s" --xml ' . $this->args;
             }
 
-            $configPath = $this->phpci->buildPath . $configPath;
-            $success = $this->phpci->executeCommand($cmd, $this->phpci->buildPath, $configPath);
-
+            $configPath = $this->buildPath . $configPath;
+            $success = $this->phpci->executeCommand($cmd, $this->buildPath, $configPath);
 
             $this->phpci->log(
-                'Codeception XML path: '. $this->phpci->buildPath . $this->path . '_output/report.xml',
+                'Codeception XML path: '. $this->buildPath . $this->path . '_output/report.xml',
                 Loglevel::DEBUG
             );
-            $xml = file_get_contents($this->phpci->buildPath . $this->path . '_output/report.xml', false);
+            $xml = file_get_contents($this->buildPath . $this->path . '_output/report.xml', false);
 
-            try {
-                $parser = new Parser($this->phpci, $xml);
-                $output = $parser->parse();
-            } catch (\Exception $ex) {
-                throw $ex;
-            }
+            $parser = new Parser($this->phpci, $xml);
+            $output = $parser->parse();
 
             $meta = array(
                 'tests' => $parser->getTotalTests(),

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -24,7 +24,7 @@ use Psr\Log\LogLevel;
  * @subpackage   Plugins
  */
 
-class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
+class Codeception extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlugin
 {
     /** @var string */
     protected $args = '';
@@ -116,9 +116,9 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         if (is_array($configPath)) {
             return $this->recurseArg($configPath, array($this, 'runConfigFile'));
         } else {
-            $this->logger->logExecOutput(false);
+            $this->executor->setQuiet(true);
 
-            $codecept = $this->phpci->findBinary('codecept');
+            $codecept = $this->executor->findBinary('codecept');
 
             $cmd = 'cd "%s" && ' . $codecept . ' run -c "%s" --tap ' . $this->args;
 
@@ -127,7 +127,7 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             }
 
             $configPath = $this->buildPath . $configPath;
-            $success = $this->phpci->executeCommand($cmd, $this->buildPath, $configPath);
+            $success = $this->executor->executeCommand($cmd, $this->buildPath, $configPath);
 
             $this->logger->log(
                 'Codeception XML path: '. $this->buildPath . $this->path . '_output/report.xml',
@@ -148,7 +148,7 @@ class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $this->build->storeMeta('codeception-data', $output);
             $this->build->storeMeta('codeception-errors', $parser->getTotalFailures());
 
-            $this->logger->logExecOutput(true);
+            $this->executor->setQuiet(false);
 
             return $success;
         }

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -136,13 +136,8 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
 
             $codecept = $this->phpci->findBinary('codecept');
 
-            if (!$codecept) {
-                $this->phpci->logFailure(Lang::get('could_not_find', 'codecept'));
+            $cmd = 'cd "%s" && ' . $codecept . ' run -c "%s" --tap ' . $this->args;
 
-                return false;
-            }
-
-            $cmd = 'cd "%s" && ' . $codecept . ' run -c "%s" --xml ' . $this->args;
             if (IS_WIN) {
                 $cmd = 'cd /d "%s" && ' . $codecept . ' run -c "%s" --xml ' . $this->args;
             }

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -23,16 +23,11 @@ use Psr\Log\LogLevel;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
+
+class Codeception extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 {
     /** @var string */
     protected $args = '';
-
-    /** @var Builder */
-    protected $phpci;
-
-    /** @var Build */
-    protected $build;
 
     /**
      * @var string $ymlConfigFile The path of a yml config for Codeception
@@ -85,8 +80,7 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
         $this->path = 'tests/';
 
         if (empty($options['config'])) {

--- a/PHPCI/Plugin/Composer.php
+++ b/PHPCI/Plugin/Composer.php
@@ -20,7 +20,7 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Composer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
+class Composer extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlugin
 {
     protected $directory;
     protected $action;
@@ -74,7 +74,7 @@ class Composer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     */
     public function execute()
     {
-        $composerLocation = $this->phpci->findBinary(array('composer', 'composer.phar'));
+        $composerLocation = $this->executor->findBinary(array('composer', 'composer.phar'));
 
         $cmd = '';
 
@@ -94,6 +94,6 @@ class Composer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 
         $cmd .= ' --working-dir="%s" %s';
 
-        return $this->phpci->executeCommand($cmd, $this->directory, $this->action);
+        return $this->executor->executeCommand($cmd, $this->directory, $this->action);
     }
 }

--- a/PHPCI/Plugin/Composer.php
+++ b/PHPCI/Plugin/Composer.php
@@ -51,7 +51,7 @@ class Composer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
      */
     protected function setOptions(array $options)
     {
-        $path = $this->phpci->buildPath;
+        $path = $this->buildPath;
         $this->directory = $path;
         $this->action = 'install';
         $this->preferDist = false;

--- a/PHPCI/Plugin/Composer.php
+++ b/PHPCI/Plugin/Composer.php
@@ -85,10 +85,10 @@ class Composer extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlugin
         $cmd .= $composerLocation . ' --no-ansi --no-interaction ';
 
         if ($this->preferDist) {
-            $this->logger->log('Using --prefer-dist flag');
+            $this->logger->notice('Using --prefer-dist flag');
             $cmd .= '--prefer-dist';
         } else {
-            $this->logger->log('Using --prefer-source flag');
+            $this->logger->notice('Using --prefer-source flag');
             $cmd .= '--prefer-source';
         }
 

--- a/PHPCI/Plugin/Composer.php
+++ b/PHPCI/Plugin/Composer.php
@@ -20,13 +20,11 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Composer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
+class Composer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 {
     protected $directory;
     protected $action;
     protected $preferDist;
-    protected $phpci;
-    protected $build;
 
     /**
      * Check if this plugin can be executed.
@@ -54,9 +52,9 @@ class Composer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
+        parent::__construct($phpci, $build);
+
         $path = $phpci->buildPath;
-        $this->phpci = $phpci;
-        $this->build = $build;
         $this->directory = $path;
         $this->action = 'install';
         $this->preferDist = false;

--- a/PHPCI/Plugin/Composer.php
+++ b/PHPCI/Plugin/Composer.php
@@ -85,10 +85,10 @@ class Composer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         $cmd .= $composerLocation . ' --no-ansi --no-interaction ';
 
         if ($this->preferDist) {
-            $this->phpci->log('Using --prefer-dist flag');
+            $this->logger->log('Using --prefer-dist flag');
             $cmd .= '--prefer-dist';
         } else {
-            $this->phpci->log('Using --prefer-source flag');
+            $this->logger->log('Using --prefer-source flag');
             $cmd .= '--prefer-source';
         }
 

--- a/PHPCI/Plugin/Composer.php
+++ b/PHPCI/Plugin/Composer.php
@@ -45,16 +45,13 @@ class Composer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     }
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $path = $phpci->buildPath;
+        $path = $this->phpci->buildPath;
         $this->directory = $path;
         $this->action = 'install';
         $this->preferDist = false;

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class CopyBuild extends AbstractPlugin
+class CopyBuild extends AbstractExecutingPlugin
 {
     protected $directory;
     protected $ignore;
@@ -53,7 +53,7 @@ class CopyBuild extends AbstractPlugin
             $cmd = 'mkdir -p "%s" && xcopy /E "%s" "%s"';
         }
 
-        $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory);
+        $success = $this->executor->executeCommand($cmd, $this->directory, $build, $this->directory);
 
         $this->deleteIgnoredFiles();
 
@@ -68,7 +68,7 @@ class CopyBuild extends AbstractPlugin
     {
         if ($this->wipe === true && $this->directory != '/' && is_dir($this->directory)) {
             $cmd = 'rm -Rf "%s*"';
-            $success = $this->phpci->executeCommand($cmd, $this->directory);
+            $success = $this->executor->executeCommand($cmd, $this->directory);
 
             if (!$success) {
                 throw new \Exception(Lang::get('failed_to_wipe', $this->directory));
@@ -87,7 +87,7 @@ class CopyBuild extends AbstractPlugin
                 if (IS_WIN) {
                     $cmd = 'rmdir /S /Q "%s\%s"';
                 }
-                $this->phpci->executeCommand($cmd, $this->directory, $file);
+                $this->executor->executeCommand($cmd, $this->directory, $file);
             }
         }
     }

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -30,7 +30,7 @@ class CopyBuild extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->directory = isset($options['directory']) ? $options['directory'] : $this->phpci->buildPath;
+        $this->directory = isset($options['directory']) ? $options['directory'] : $this->buildPath;
         $this->wipe      = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
         $this->ignore    = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;
     }
@@ -40,7 +40,7 @@ class CopyBuild extends AbstractPlugin
     */
     public function execute()
     {
-        $build = $this->phpci->buildPath;
+        $build = $this->buildPath;
 
         if ($this->directory == $build) {
             return false;

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -9,8 +9,6 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
-use PHPCI\Model\Build;
 use PHPCI\Helper\Lang;
 
 /**
@@ -26,19 +24,15 @@ class CopyBuild extends AbstractPlugin
     protected $wipe;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $path               = $phpci->buildPath;
-        $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
-        $this->wipe         = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
-        $this->ignore       = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;
+        $this->directory = isset($options['directory']) ? $options['directory'] : $this->phpci->buildPath;
+        $this->wipe      = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
+        $this->ignore    = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;
     }
 
     /**

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -20,7 +20,7 @@ use PHPCI\Helper\Lang;
 class CopyBuild extends AbstractExecutingPlugin
 {
     protected $directory;
-    protected $ignore;
+    protected $respect_ignore;
     protected $wipe;
 
     /**
@@ -81,8 +81,8 @@ class CopyBuild extends AbstractExecutingPlugin
      */
     protected function deleteIgnoredFiles()
     {
-        if ($this->ignore) {
-            foreach ($this->phpci->ignore as $file) {
+        if ($this->respect_ignore) {
+            foreach ($this->ignore as $file) {
                 $cmd = 'rm -Rf "%s/%s"';
                 if (IS_WIN) {
                     $cmd = 'rmdir /S /Q "%s\%s"';

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -19,13 +19,11 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class CopyBuild implements \PHPCI\Plugin
+class CopyBuild extends AbstractPlugin
 {
     protected $directory;
     protected $ignore;
     protected $wipe;
-    protected $phpci;
-    protected $build;
 
     /**
      * Set up the plugin, configure options, etc.
@@ -35,9 +33,9 @@ class CopyBuild implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
+        parent::__construct($phpci, $build);
+
         $path               = $phpci->buildPath;
-        $this->phpci        = $phpci;
-        $this->build = $build;
         $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
         $this->wipe         = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
         $this->ignore       = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;

--- a/PHPCI/Plugin/Email.php
+++ b/PHPCI/Plugin/Email.php
@@ -65,8 +65,10 @@ class Email extends AbstractPlugin
         );
 
         // This is a success if we've not failed to send anything.
-        $this->logger->log(sprintf("%d emails sent", (count($addresses) - $sendFailures)));
-        $this->logger->log(sprintf("%d emails failed to send", $sendFailures));
+        $this->logger->notice(sprintf("%d emails sent", (count($addresses) - $sendFailures)));
+        if ($sendFailures > 0) {
+            $this->logger->error(sprintf("%d emails failed to send", $sendFailures));
+        }
 
         return ($sendFailures === 0);
     }

--- a/PHPCI/Plugin/Email.php
+++ b/PHPCI/Plugin/Email.php
@@ -10,9 +10,7 @@
 namespace PHPCI\Plugin;
 
 use b8\View;
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 use PHPCI\Helper\Email as EmailHelper;
 
 /**
@@ -29,20 +27,13 @@ class Email extends AbstractPlugin
     protected $options;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
-     * @param \Swift_Mailer $mailer
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(
-        Builder $phpci,
-        Build $build,
-        array $options = array()
-    ) {
-        parent::__construct($phpci, $build);
-
-        $this->options      = $options;
+    protected function setOptions(array $options)
+    {
+        $this->options = $options;
     }
 
     /**

--- a/PHPCI/Plugin/Email.php
+++ b/PHPCI/Plugin/Email.php
@@ -21,18 +21,8 @@ use PHPCI\Helper\Email as EmailHelper;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Email implements \PHPCI\Plugin
+class Email extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     /**
      * @var array
      */
@@ -50,8 +40,8 @@ class Email implements \PHPCI\Plugin
         Build $build,
         array $options = array()
     ) {
-        $this->phpci        = $phpci;
-        $this->build        = $build;
+        parent::__construct($phpci, $build);
+
         $this->options      = $options;
     }
 

--- a/PHPCI/Plugin/Email.php
+++ b/PHPCI/Plugin/Email.php
@@ -65,8 +65,8 @@ class Email extends AbstractPlugin
         );
 
         // This is a success if we've not failed to send anything.
-        $this->phpci->log(sprintf("%d emails sent", (count($addresses) - $sendFailures)));
-        $this->phpci->log(sprintf("%d emails failed to send", $sendFailures));
+        $this->logger->log(sprintf("%d emails sent", (count($addresses) - $sendFailures)));
+        $this->logger->log(sprintf("%d emails failed to send", $sendFailures));
 
         return ($sendFailures === 0);
     }

--- a/PHPCI/Plugin/Env.php
+++ b/PHPCI/Plugin/Env.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
 * Environment variable plugin
@@ -24,15 +22,12 @@ class Env extends AbstractPlugin
     protected $env_vars;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->env_vars = $options;
     }
 

--- a/PHPCI/Plugin/Env.php
+++ b/PHPCI/Plugin/Env.php
@@ -19,10 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Env implements \PHPCI\Plugin
+class Env extends AbstractPlugin
 {
-    protected $phpci;
-    protected $build;
     protected $env_vars;
 
     /**
@@ -33,8 +31,8 @@ class Env implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->env_vars = $options;
     }
 
@@ -52,7 +50,7 @@ class Env implements \PHPCI\Plugin
                 // This allows the standard syntax: "FOO: bar"
                 $env_var = "$key=$value";
             }
-            
+
             if (!putenv($this->phpci->interpolate($env_var))) {
                 $success = false;
                 $this->phpci->logFailure(Lang::get('unable_to_set_env'));

--- a/PHPCI/Plugin/Env.php
+++ b/PHPCI/Plugin/Env.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Env extends AbstractPlugin
+class Env extends AbstractInterpolatingPlugin
 {
     protected $env_vars;
 
@@ -46,9 +46,8 @@ class Env extends AbstractPlugin
                 $env_var = "$key=$value";
             }
 
-            if (!putenv($this->phpci->interpolate($env_var))) {
-                $success = false;
-                $this->phpci->logFailure(Lang::get('unable_to_set_env'));
+            if (!putenv($this->interpolator->interpolate($env_var))) {
+                throw new RuntimeException(Lang::get('unable_to_set_env'));
             }
         }
         return $success;

--- a/PHPCI/Plugin/Git.php
+++ b/PHPCI/Plugin/Git.php
@@ -37,7 +37,7 @@ class Git extends AbstractPlugin
      */
     public function execute()
     {
-        $buildPath = $this->phpci->buildPath;
+        $buildPath = $this->buildPath;
 
         // Check if there are any actions to be run for the branch we're running on:
         if (!array_key_exists($this->build->getBranch(), $this->actions)) {
@@ -96,7 +96,7 @@ class Git extends AbstractPlugin
     {
         if (array_key_exists('branch', $options)) {
             $cmd = 'cd "%s" && git checkout %s && git merge "%s"';
-            $path = $this->phpci->buildPath;
+            $path = $this->buildPath;
             return $this->phpci->executeCommand($cmd, $path, $options['branch'], $this->build->getBranch());
         }
     }

--- a/PHPCI/Plugin/Git.php
+++ b/PHPCI/Plugin/Git.php
@@ -97,7 +97,7 @@ class Git extends AbstractInterpolatingPlugin
         if (array_key_exists('branch', $options)) {
             $cmd = 'cd "%s" && git checkout %s && git merge "%s"';
             $path = $this->buildPath;
-            return $this->phpci->executeCommand($cmd, $path, $options['branch'], $this->build->getBranch());
+            return $this->executor->executeCommand($cmd, $path, $options['branch'], $this->build->getBranch());
         }
     }
 
@@ -120,7 +120,7 @@ class Git extends AbstractInterpolatingPlugin
         }
 
         $cmd = 'git tag %s -m "%s"';
-        return $this->phpci->executeCommand($cmd, $tagName, $message);
+        return $this->executor->executeCommand($cmd, $tagName, $message);
     }
 
     /**
@@ -141,7 +141,7 @@ class Git extends AbstractInterpolatingPlugin
             $remote = $this->interpolator->interpolate($options['remote']);
         }
 
-        return $this->phpci->executeCommand('git pull %s %s', $remote, $branch);
+        return $this->executor->executeCommand('git pull %s %s', $remote, $branch);
     }
 
     /**
@@ -162,6 +162,6 @@ class Git extends AbstractInterpolatingPlugin
             $remote = $this->interpolator->interpolate($options['remote']);
         }
 
-        return $this->phpci->executeCommand('git push %s %s', $remote, $branch);
+        return $this->executor->executeCommand('git push %s %s', $remote, $branch);
     }
 }

--- a/PHPCI/Plugin/Git.php
+++ b/PHPCI/Plugin/Git.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Git extends AbstractPlugin
+class Git extends AbstractInterpolatingPlugin
 {
     protected $actions = array();
 
@@ -112,11 +112,11 @@ class Git extends AbstractPlugin
         $message = Lang::get('tag_created', date('Y-m-d H:i:s'));
 
         if (array_key_exists('name', $options)) {
-            $tagName = $this->phpci->interpolate($options['name']);
+            $tagName = $this->interpolator->interpolate($options['name']);
         }
 
         if (array_key_exists('message', $options)) {
-            $message = $this->phpci->interpolate($options['message']);
+            $message = $this->interpolator->interpolate($options['message']);
         }
 
         $cmd = 'git tag %s -m "%s"';
@@ -134,11 +134,11 @@ class Git extends AbstractPlugin
         $remote = 'origin';
 
         if (array_key_exists('branch', $options)) {
-            $branch = $this->phpci->interpolate($options['branch']);
+            $branch = $this->interpolator->interpolate($options['branch']);
         }
 
         if (array_key_exists('remote', $options)) {
-            $remote = $this->phpci->interpolate($options['remote']);
+            $remote = $this->interpolator->interpolate($options['remote']);
         }
 
         return $this->phpci->executeCommand('git pull %s %s', $remote, $branch);
@@ -155,11 +155,11 @@ class Git extends AbstractPlugin
         $remote = 'origin';
 
         if (array_key_exists('branch', $options)) {
-            $branch = $this->phpci->interpolate($options['branch']);
+            $branch = $this->interpolator->interpolate($options['branch']);
         }
 
         if (array_key_exists('remote', $options)) {
-            $remote = $this->phpci->interpolate($options['remote']);
+            $remote = $this->interpolator->interpolate($options['remote']);
         }
 
         return $this->phpci->executeCommand('git push %s %s', $remote, $branch);

--- a/PHPCI/Plugin/Git.php
+++ b/PHPCI/Plugin/Git.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * Git plugin.
@@ -24,15 +22,12 @@ class Git extends AbstractPlugin
     protected $actions = array();
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->actions = $options;
     }
 

--- a/PHPCI/Plugin/Git.php
+++ b/PHPCI/Plugin/Git.php
@@ -19,10 +19,8 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Git implements \PHPCI\Plugin
+class Git extends AbstractPlugin
 {
-    protected $phpci;
-    protected $build;
     protected $actions = array();
 
     /**
@@ -33,8 +31,8 @@ class Git implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->actions = $options;
     }
 

--- a/PHPCI/Plugin/Grunt.php
+++ b/PHPCI/Plugin/Grunt.php
@@ -18,13 +18,11 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Grunt implements \PHPCI\Plugin
+class Grunt extends AbstractPlugin
 {
     protected $directory;
     protected $task;
     protected $preferDist;
-    protected $phpci;
-    protected $build;
     protected $grunt;
     protected $gruntfile;
 
@@ -42,9 +40,9 @@ class Grunt implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
+        parent::__construct($phpci, $build);
+
         $path = $phpci->buildPath;
-        $this->build = $build;
-        $this->phpci = $phpci;
         $this->directory = $path;
         $this->task = null;
         $this->grunt = $this->phpci->findBinary('grunt');

--- a/PHPCI/Plugin/Grunt.php
+++ b/PHPCI/Plugin/Grunt.php
@@ -30,14 +30,14 @@ class Grunt extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->directory = $this->phpci->buildPath;
+        $this->directory = $this->buildPath;
         $this->task = null;
         $this->grunt = $this->phpci->findBinary('grunt');
         $this->gruntfile = 'Gruntfile.js';
 
         // Handle options:
         if (isset($options['directory'])) {
-            $this->directory = $this->phpci->buildPath . '/' . $options['directory'];
+            $this->directory = $this->buildPath . '/' . $options['directory'];
         }
 
         if (isset($options['task'])) {

--- a/PHPCI/Plugin/Grunt.php
+++ b/PHPCI/Plugin/Grunt.php
@@ -9,9 +9,6 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
-use PHPCI\Model\Build;
-
 /**
 * Grunt Plugin - Provides access to grunt functionality.
 * @author       Tobias Tom <t.tom@succont.de>
@@ -27,30 +24,20 @@ class Grunt extends AbstractPlugin
     protected $gruntfile;
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $path = $phpci->buildPath;
-        $this->directory = $path;
+        $this->directory = $this->phpci->buildPath;
         $this->task = null;
         $this->grunt = $this->phpci->findBinary('grunt');
         $this->gruntfile = 'Gruntfile.js';
 
         // Handle options:
         if (isset($options['directory'])) {
-            $this->directory = $path . '/' . $options['directory'];
+            $this->directory = $this->phpci->buildPath . '/' . $options['directory'];
         }
 
         if (isset($options['task'])) {

--- a/PHPCI/Plugin/Grunt.php
+++ b/PHPCI/Plugin/Grunt.php
@@ -15,7 +15,7 @@ namespace PHPCI\Plugin;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Grunt extends AbstractPlugin
+class Grunt extends AbstractExecutingPlugin
 {
     protected $directory;
     protected $task;
@@ -32,7 +32,7 @@ class Grunt extends AbstractPlugin
     {
         $this->directory = $this->buildPath;
         $this->task = null;
-        $this->grunt = $this->phpci->findBinary('grunt');
+        $this->grunt = $this->executor->findBinary('grunt');
         $this->gruntfile = 'Gruntfile.js';
 
         // Handle options:
@@ -63,7 +63,7 @@ class Grunt extends AbstractPlugin
         if (IS_WIN) {
             $cmd = 'cd /d %s && npm install';
         }
-        if (!$this->phpci->executeCommand($cmd, $this->directory)) {
+        if (!$this->executor->executeCommand($cmd, $this->directory)) {
             return false;
         }
 
@@ -77,6 +77,6 @@ class Grunt extends AbstractPlugin
         $cmd .= ' %s'; // the task that will be executed
 
         // and execute it
-        return $this->phpci->executeCommand($cmd, $this->directory, $this->gruntfile, $this->task);
+        return $this->executor->executeCommand($cmd, $this->directory, $this->gruntfile, $this->task);
     }
 }

--- a/PHPCI/Plugin/Gulp.php
+++ b/PHPCI/Plugin/Gulp.php
@@ -18,13 +18,11 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Gulp implements \PHPCI\Plugin
+class Gulp extends AbstractPlugin
 {
     protected $directory;
     protected $task;
     protected $preferDist;
-    protected $phpci;
-    protected $build;
     protected $gulp;
     protected $gulpfile;
 
@@ -42,9 +40,9 @@ class Gulp implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
+        parent::__construct($phpci, $build);
+
         $path = $phpci->buildPath;
-        $this->build = $build;
-        $this->phpci = $phpci;
         $this->directory = $path;
         $this->task = null;
         $this->gulp = $this->phpci->findBinary('gulp');

--- a/PHPCI/Plugin/Gulp.php
+++ b/PHPCI/Plugin/Gulp.php
@@ -30,14 +30,14 @@ class Gulp extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->directory = $this->phpci->buildPath;
+        $this->directory = $this->buildPath;
         $this->task = null;
         $this->gulp = $this->phpci->findBinary('gulp');
         $this->gulpfile = 'gulpfile.js';
 
         // Handle options:
         if (isset($options['directory'])) {
-            $this->directory = $this->phpci->buildPath . '/' . $options['directory'];
+            $this->directory = $this->buildPath . '/' . $options['directory'];
         }
 
         if (isset($options['task'])) {

--- a/PHPCI/Plugin/Gulp.php
+++ b/PHPCI/Plugin/Gulp.php
@@ -9,9 +9,6 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
-use PHPCI\Model\Build;
-
 /**
 * Gulp Plugin - Provides access to gulp functionality.
 * @author       Dirk Heilig <dirk@heilig-online.com>
@@ -27,30 +24,20 @@ class Gulp extends AbstractPlugin
     protected $gulpfile;
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $path = $phpci->buildPath;
-        $this->directory = $path;
+        $this->directory = $this->phpci->buildPath;
         $this->task = null;
         $this->gulp = $this->phpci->findBinary('gulp');
         $this->gulpfile = 'gulpfile.js';
 
         // Handle options:
         if (isset($options['directory'])) {
-            $this->directory = $path . '/' . $options['directory'];
+            $this->directory = $this->phpci->buildPath . '/' . $options['directory'];
         }
 
         if (isset($options['task'])) {

--- a/PHPCI/Plugin/Gulp.php
+++ b/PHPCI/Plugin/Gulp.php
@@ -15,7 +15,7 @@ namespace PHPCI\Plugin;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Gulp extends AbstractPlugin
+class Gulp extends AbstractExecutingPlugin
 {
     protected $directory;
     protected $task;
@@ -32,7 +32,7 @@ class Gulp extends AbstractPlugin
     {
         $this->directory = $this->buildPath;
         $this->task = null;
-        $this->gulp = $this->phpci->findBinary('gulp');
+        $this->gulp = $this->executor->findBinary('gulp');
         $this->gulpfile = 'gulpfile.js';
 
         // Handle options:
@@ -63,7 +63,7 @@ class Gulp extends AbstractPlugin
         if (IS_WIN) {
             $cmd = 'cd /d %s && npm install';
         }
-        if (!$this->phpci->executeCommand($cmd, $this->directory)) {
+        if (!$this->executor->executeCommand($cmd, $this->directory)) {
             return false;
         }
 
@@ -77,6 +77,6 @@ class Gulp extends AbstractPlugin
         $cmd .= ' %s'; // the task that will be executed
 
         // and execute it
-        return $this->phpci->executeCommand($cmd, $this->directory, $this->gulpfile, $this->task);
+        return $this->executor->executeCommand($cmd, $this->directory, $this->gulpfile, $this->task);
     }
 }

--- a/PHPCI/Plugin/HipchatNotify.php
+++ b/PHPCI/Plugin/HipchatNotify.php
@@ -64,7 +64,6 @@ class HipchatNotify implements \PHPCI\Plugin
         } else {
             throw new \Exception(Lang::get('hipchat_settings'));
         }
-
     }
 
     /**

--- a/PHPCI/Plugin/HipchatNotify.php
+++ b/PHPCI/Plugin/HipchatNotify.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * Hipchat Plugin
@@ -26,16 +24,12 @@ class HipchatNotify extends AbstractPlugin
     protected $notify;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
-     * @throws \Exception
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->userAgent = "PHPCI/1.0 (+http://www.phptesting.org/)";
         $this->cookie = "phpcicookie";
 

--- a/PHPCI/Plugin/HipchatNotify.php
+++ b/PHPCI/Plugin/HipchatNotify.php
@@ -19,7 +19,7 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class HipchatNotify implements \PHPCI\Plugin
+class HipchatNotify extends AbstractPlugin
 {
     protected $authToken;
     protected $color;
@@ -34,8 +34,7 @@ class HipchatNotify implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         $this->userAgent = "PHPCI/1.0 (+http://www.phptesting.org/)";
         $this->cookie = "phpcicookie";

--- a/PHPCI/Plugin/HipchatNotify.php
+++ b/PHPCI/Plugin/HipchatNotify.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class HipchatNotify extends AbstractPlugin
+class HipchatNotify extends AbstractInterpolatingPlugin
 {
     protected $authToken;
     protected $color;
@@ -66,7 +66,7 @@ class HipchatNotify extends AbstractPlugin
     public function execute()
     {
         $hipChat = new \HipChat\HipChat($this->authToken);
-        $message = $this->phpci->interpolate($this->message);
+        $message = $this->interpolator->interpolate($this->message);
 
         $result = true;
         if (is_array($this->room)) {

--- a/PHPCI/Plugin/Irc.php
+++ b/PHPCI/Plugin/Irc.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * IRC Plugin - Sends a notification to an IRC channel
@@ -28,24 +26,15 @@ class Irc extends AbstractPlugin
     protected $nick;
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->message = $options['message'];
 
-        $buildSettings = $phpci->getConfig('build_settings');
+        $buildSettings = $this->phpci->getConfig('build_settings');
 
 
         if (isset($buildSettings['irc'])) {

--- a/PHPCI/Plugin/Irc.php
+++ b/PHPCI/Plugin/Irc.php
@@ -19,10 +19,8 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Irc implements \PHPCI\Plugin
+class Irc extends AbstractPlugin
 {
-    protected $phpci;
-    protected $build;
     protected $message;
     protected $server;
     protected $port;
@@ -43,8 +41,8 @@ class Irc implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->message = $options['message'];
 
         $buildSettings = $phpci->getConfig('build_settings');

--- a/PHPCI/Plugin/Irc.php
+++ b/PHPCI/Plugin/Irc.php
@@ -42,7 +42,7 @@ class Irc extends AbstractInterpolatingPlugin
     {
         parent::setCommonSettings($settings);
 
-        if(!isset($settings['server'], $settings['room'], $settings['nick'])) {
+        if (!isset($settings['server'], $settings['room'], $settings['nick'])) {
             throw new \Exception(Lang::get('irc_settings'));
         }
 

--- a/PHPCI/Plugin/Irc.php
+++ b/PHPCI/Plugin/Irc.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Irc extends AbstractPlugin
+class Irc extends AbstractInterpolatingPlugin
 {
     protected $message;
     protected $server;
@@ -53,7 +53,7 @@ class Irc extends AbstractPlugin
      */
     public function execute()
     {
-        $msg = $this->phpci->interpolate($this->message);
+        $msg = $this->interpolator->interpolate($this->message);
 
         if (empty($this->server) || empty($this->room) || empty($this->nick)) {
             $this->phpci->logFailure(Lang::get('irc_settings'));

--- a/PHPCI/Plugin/Irc.php
+++ b/PHPCI/Plugin/Irc.php
@@ -33,18 +33,23 @@ class Irc extends AbstractInterpolatingPlugin
     protected function setOptions(array $options)
     {
         $this->message = $options['message'];
+    }
 
-        $buildSettings = $this->phpci->getConfig('build_settings');
+    /**
+     * {@inheritdoc}
+     */
+    protected function setCommonSettings(array $settings)
+    {
+        parent::setCommonSettings($settings);
 
-
-        if (isset($buildSettings['irc'])) {
-            $irc = $buildSettings['irc'];
-
-            $this->server = $irc['server'];
-            $this->port = $irc['port'];
-            $this->room = $irc['room'];
-            $this->nick = $irc['nick'];
+        if(!isset($settings['server'], $settings['room'], $settings['nick'])) {
+            throw new \Exception(Lang::get('irc_settings'));
         }
+
+        $this->server = $settings['server'];
+        $this->port = isset($settings['port']) ? $settings['port'] : 6667;
+        $this->room = $settings['room'];
+        $this->nick = $settings['nick'];
     }
 
     /**
@@ -54,14 +59,6 @@ class Irc extends AbstractInterpolatingPlugin
     public function execute()
     {
         $msg = $this->interpolator->interpolate($this->message);
-
-        if (empty($this->server) || empty($this->room) || empty($this->nick)) {
-            throw new \Exception(Lang::get('irc_settings'));
-        }
-
-        if (empty($this->port)) {
-            $this->port = 6667;
-        }
 
         $sock = fsockopen($this->server, $this->port);
         stream_set_timeout($sock, 1);

--- a/PHPCI/Plugin/Irc.php
+++ b/PHPCI/Plugin/Irc.php
@@ -56,7 +56,7 @@ class Irc extends AbstractInterpolatingPlugin
         $msg = $this->interpolator->interpolate($this->message);
 
         if (empty($this->server) || empty($this->room) || empty($this->nick)) {
-            $this->phpci->logFailure(Lang::get('irc_settings'));
+            throw new \Exception(Lang::get('irc_settings'));
         }
 
         if (empty($this->port)) {

--- a/PHPCI/Plugin/Lint.php
+++ b/PHPCI/Plugin/Lint.php
@@ -17,7 +17,7 @@ use PHPCI;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Lint extends AbstractPlugin
+class Lint extends AbstractExecutingPlugin
 {
     protected $directories;
     protected $recursive = true;
@@ -51,10 +51,10 @@ class Lint extends AbstractPlugin
      */
     public function execute()
     {
-        $this->phpci->quiet = true;
+        $this->executor->setQuiet(true);
         $success = true;
 
-        $php = $this->phpci->findBinary('php');
+        $php = $this->executor->findBinary('php');
 
         foreach ($this->directories as $dir) {
             if (!$this->lintDirectory($php, $dir)) {
@@ -62,7 +62,7 @@ class Lint extends AbstractPlugin
             }
         }
 
-        $this->phpci->quiet = false;
+        $this->executor->setQuiet(false);
 
         return $success;
     }
@@ -127,7 +127,7 @@ class Lint extends AbstractPlugin
     {
         $success = true;
 
-        if (!$this->phpci->executeCommand($php . ' -l "%s"', $this->phpci->buildPath . $path)) {
+        if (!$this->executor->executeCommand($php . ' -l "%s"', $this->buildPath . $path)) {
             $this->logger->logFailure($path);
             $success = false;
         }

--- a/PHPCI/Plugin/Lint.php
+++ b/PHPCI/Plugin/Lint.php
@@ -128,7 +128,7 @@ class Lint extends AbstractPlugin
         $success = true;
 
         if (!$this->phpci->executeCommand($php . ' -l "%s"', $this->phpci->buildPath . $path)) {
-            $this->phpci->logFailure($path);
+            $this->logger->logFailure($path);
             $success = false;
         }
 

--- a/PHPCI/Plugin/Lint.php
+++ b/PHPCI/Plugin/Lint.php
@@ -21,7 +21,6 @@ class Lint extends AbstractExecutingPlugin
 {
     protected $directories;
     protected $recursive = true;
-    protected $ignore;
 
     /**
      * Configure the plugin.
@@ -31,7 +30,6 @@ class Lint extends AbstractExecutingPlugin
     protected function setOptions(array $options)
     {
         $this->directories    = array('');
-        $this->ignore = $this->phpci->ignore;
 
         if (!empty($options['directory'])) {
             $this->directories[] = $options['directory'];

--- a/PHPCI/Plugin/Lint.php
+++ b/PHPCI/Plugin/Lint.php
@@ -19,13 +19,11 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Lint implements PHPCI\Plugin
+class Lint extends AbstractPlugin
 {
     protected $directories;
     protected $recursive = true;
     protected $ignore;
-    protected $phpci;
-    protected $build;
 
     /**
      * Standard Constructor
@@ -41,8 +39,8 @@ class Lint implements PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci        = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->directories    = array('');
         $this->ignore = $phpci->ignore;
 

--- a/PHPCI/Plugin/Lint.php
+++ b/PHPCI/Plugin/Lint.php
@@ -96,7 +96,7 @@ class Lint extends AbstractPlugin
     protected function lintDirectory($php, $path)
     {
         $success = true;
-        $directory = new \DirectoryIterator($this->phpci->buildPath . $path);
+        $directory = new \DirectoryIterator($this->buildPath . $path);
 
         foreach ($directory as $item) {
             if ($item->isDot()) {

--- a/PHPCI/Plugin/Lint.php
+++ b/PHPCI/Plugin/Lint.php
@@ -126,7 +126,7 @@ class Lint extends AbstractExecutingPlugin
         $success = true;
 
         if (!$this->executor->executeCommand($php . ' -l "%s"', $this->buildPath . $path)) {
-            $this->logger->logFailure($path);
+            $this->logger->error($path);
             $success = false;
         }
 

--- a/PHPCI/Plugin/Lint.php
+++ b/PHPCI/Plugin/Lint.php
@@ -10,8 +10,6 @@
 namespace PHPCI\Plugin;
 
 use PHPCI;
-use PHPCI\Builder;
-use PHPCI\Model\Build;
 
 /**
  * PHP Lint Plugin - Provides access to PHP lint functionality.
@@ -26,23 +24,14 @@ class Lint extends AbstractPlugin
     protected $ignore;
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->directories    = array('');
-        $this->ignore = $phpci->ignore;
+        $this->ignore = $this->phpci->ignore;
 
         if (!empty($options['directory'])) {
             $this->directories[] = $options['directory'];

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -49,29 +49,23 @@ class Mysql extends AbstractInterpolatingPlugin
     protected function setOptions(array $options)
     {
         $this->queries = $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setCommonSettings(array $settings)
+    {
+        parent::setCommonSettings($settings);
 
         $config = \b8\Database::getConnection('write')->getDetails();
 
-        $this->host =(defined('PHPCI_DB_HOST')) ? PHPCI_DB_HOST : null;
-        $this->user = $config['user'];
-        $this->pass = $config['pass'];
-
-        $buildSettings = $this->phpci->getConfig('build_settings');
-
-        if (!isset($buildSettings['mysql'])) {
-            return;
-        }
-
-        if (!empty($buildSettings['mysql']['host'])) {
-            $this->host = $this->interpolator->interpolate($buildSettings['mysql']['host']);
-        }
-
-        if (!empty($buildSettings['mysql']['user'])) {
-            $this->user = $this->interpolator->interpolate($buildSettings['mysql']['user']);
-        }
-
-        if (array_key_exists('pass', $buildSettings['mysql'])) {
-            $this->pass = $buildSettings['mysql']['pass'];
+        foreach (array('host', 'user', 'pass') as $param) {
+            if (isset($settings[$param])) {
+                $this->{$param} = $this->interpolator->interpolate($settings[$param]);
+            } else {
+                $this->{$param} = $config[$param];
+            }
         }
     }
 

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -114,7 +114,7 @@ class Mysql extends AbstractPlugin
             throw new \Exception(Lang::get('import_file_key'));
         }
 
-        $import_file = $this->phpci->buildPath . $this->phpci->interpolate($query['file']);
+        $import_file = $this->buildPath . $this->phpci->interpolate($query['file']);
         if (!is_readable($import_file)) {
             throw new \Exception(Lang::get('cannot_open_import', $import_file));
         }

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -21,18 +21,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Mysql implements \PHPCI\Plugin
+class Mysql extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     /**
      * @var array
      */
@@ -60,8 +50,7 @@ class Mysql implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         $this->queries = $options;
 

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -122,7 +122,7 @@ class Mysql extends AbstractInterpolatingPlugin
         $database = isset($query['database']) ? $this->interpolator->interpolate($query['database']) : null;
 
         $import_command = $this->getImportCommand($import_file, $database);
-        if (!$this->phpci->executeCommand($import_command)) {
+        if (!$this->executor->executeCommand($import_command)) {
             throw new \Exception(Lang::get('unable_to_execute'));
         }
 

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -75,24 +75,19 @@ class Mysql extends AbstractInterpolatingPlugin
     */
     public function execute()
     {
-        try {
-            $opts = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
-            $pdo  = new PDO('mysql:host=' . $this->host, $this->user, $this->pass, $opts);
+        $opts = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
+        $pdo  = new PDO('mysql:host=' . $this->host, $this->user, $this->pass, $opts);
 
-            foreach ($this->queries as $query) {
-                if (!is_array($query)) {
-                    // Simple query
-                    $pdo->query($this->interpolator->interpolate($query));
-                } elseif (isset($query['import'])) {
-                    // SQL file execution
-                    $this->executeFile($query['import']);
-                } else {
-                    throw new \Exception(Lang::get('invalid_command'));
-                }
+        foreach ($this->queries as $query) {
+            if (!is_array($query)) {
+                // Simple query
+                $pdo->query($this->interpolator->interpolate($query));
+            } elseif (isset($query['import'])) {
+                // SQL file execution
+                $this->executeFile($query['import']);
+            } else {
+                throw new \Exception(Lang::get('invalid_command'));
             }
-        } catch (\Exception $ex) {
-            $this->logger->logFailure($ex->getMessage());
-            return false;
         }
         return true;
     }

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -97,7 +97,7 @@ class Mysql extends AbstractPlugin
                 }
             }
         } catch (\Exception $ex) {
-            $this->phpci->logFailure($ex->getMessage());
+            $this->logger->logFailure($ex->getMessage());
             return false;
         }
         return true;

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -19,7 +19,7 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Mysql extends AbstractPlugin
+class Mysql extends AbstractInterpolatingPlugin
 {
     /**
      * @var array
@@ -63,11 +63,11 @@ class Mysql extends AbstractPlugin
         }
 
         if (!empty($buildSettings['mysql']['host'])) {
-            $this->host = $this->phpci->interpolate($buildSettings['mysql']['host']);
+            $this->host = $this->interpolator->interpolate($buildSettings['mysql']['host']);
         }
 
         if (!empty($buildSettings['mysql']['user'])) {
-            $this->user = $this->phpci->interpolate($buildSettings['mysql']['user']);
+            $this->user = $this->interpolator->interpolate($buildSettings['mysql']['user']);
         }
 
         if (array_key_exists('pass', $buildSettings['mysql'])) {
@@ -88,7 +88,7 @@ class Mysql extends AbstractPlugin
             foreach ($this->queries as $query) {
                 if (!is_array($query)) {
                     // Simple query
-                    $pdo->query($this->phpci->interpolate($query));
+                    $pdo->query($this->interpolator->interpolate($query));
                 } elseif (isset($query['import'])) {
                     // SQL file execution
                     $this->executeFile($query['import']);
@@ -114,12 +114,12 @@ class Mysql extends AbstractPlugin
             throw new \Exception(Lang::get('import_file_key'));
         }
 
-        $import_file = $this->buildPath . $this->phpci->interpolate($query['file']);
+        $import_file = $this->buildPath . $this->interpolator->interpolate($query['file']);
         if (!is_readable($import_file)) {
             throw new \Exception(Lang::get('cannot_open_import', $import_file));
         }
 
-        $database = isset($query['database']) ? $this->phpci->interpolate($query['database']) : null;
+        $database = isset($query['database']) ? $this->interpolator->interpolate($query['database']) : null;
 
         $import_command = $this->getImportCommand($import_file, $database);
         if (!$this->phpci->executeCommand($import_command)) {

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -10,9 +10,7 @@
 namespace PHPCI\Plugin;
 
 use PDO;
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
 * MySQL Plugin - Provides access to a MySQL database.
@@ -44,14 +42,12 @@ class Mysql extends AbstractPlugin
     protected $pass;
 
     /**
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * Configure the plugin.
+     *
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->queries = $options;
 
         $config = \b8\Database::getConnection('write')->getDetails();
@@ -60,7 +56,7 @@ class Mysql extends AbstractPlugin
         $this->user = $config['user'];
         $this->pass = $config['pass'];
 
-        $buildSettings = $phpci->getConfig('build_settings');
+        $buildSettings = $this->phpci->getConfig('build_settings');
 
         if (!isset($buildSettings['mysql'])) {
             return;

--- a/PHPCI/Plugin/PackageBuild.php
+++ b/PHPCI/Plugin/PackageBuild.php
@@ -69,8 +69,7 @@ class PackageBuild implements \PHPCI\Plugin
         }
 
         foreach ($this->format as $format) {
-            switch($format)
-            {
+            switch ($format) {
                 case 'tar':
                     $cmd = 'tar cfz "%s/%s.tar.gz" ./*';
                     break;

--- a/PHPCI/Plugin/PackageBuild.php
+++ b/PHPCI/Plugin/PackageBuild.php
@@ -28,7 +28,7 @@ class PackageBuild extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->directory    = isset($options['directory']) ? $options['directory'] : $this->phpci->buildPath;
+        $this->directory    = isset($options['directory']) ? $options['directory'] : $this->buildPath;
         $this->filename     = isset($options['filename']) ? $options['filename'] : 'build';
         $this->format       = isset($options['format']) ?  $options['format'] : 'zip';
     }
@@ -38,7 +38,7 @@ class PackageBuild extends AbstractPlugin
     */
     public function execute()
     {
-        $path = $this->phpci->buildPath;
+        $path = $this->buildPath;
         $build = $this->build;
 
         if ($this->directory == $path) {
@@ -54,7 +54,7 @@ class PackageBuild extends AbstractPlugin
         $filename = preg_replace('/([^a-zA-Z0-9_-]+)/', '', $filename);
 
         $curdir = getcwd();
-        chdir($this->phpci->buildPath);
+        chdir($this->buildPath);
 
         if (!is_array($this->format)) {
             $this->format = array($this->format);

--- a/PHPCI/Plugin/PackageBuild.php
+++ b/PHPCI/Plugin/PackageBuild.php
@@ -15,7 +15,7 @@ namespace PHPCI\Plugin;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PackageBuild extends AbstractPlugin
+class PackageBuild extends AbstractExecutingPlugin
 {
     protected $directory;
     protected $filename;
@@ -71,7 +71,7 @@ class PackageBuild extends AbstractPlugin
                     break;
             }
 
-            $success = $this->phpci->executeCommand($cmd, $this->directory, $filename);
+            $success = $this->executor->executeCommand($cmd, $this->directory, $filename);
         }
 
         chdir($curdir);

--- a/PHPCI/Plugin/PackageBuild.php
+++ b/PHPCI/Plugin/PackageBuild.php
@@ -18,12 +18,11 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PackageBuild implements \PHPCI\Plugin
+class PackageBuild extends AbstractPlugin
 {
     protected $directory;
     protected $filename;
     protected $format;
-    protected $phpci;
 
     /**
      * Set up the plugin, configure options, etc.
@@ -33,9 +32,9 @@ class PackageBuild implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
+        parent::__construct($phpci, $build);
+
         $path               = $phpci->buildPath;
-        $this->build        = $build;
-        $this->phpci        = $phpci;
         $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
         $this->filename     = isset($options['filename']) ? $options['filename'] : 'build';
         $this->format       = isset($options['format']) ?  $options['format'] : 'zip';

--- a/PHPCI/Plugin/PackageBuild.php
+++ b/PHPCI/Plugin/PackageBuild.php
@@ -9,9 +9,6 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
-use PHPCI\Model\Build;
-
 /**
 * Create a ZIP or TAR.GZ archive of the entire build.
 * @author       Dan Cryer <dan@block8.co.uk>
@@ -25,17 +22,13 @@ class PackageBuild extends AbstractPlugin
     protected $format;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $path               = $phpci->buildPath;
-        $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
+        $this->directory    = isset($options['directory']) ? $options['directory'] : $this->phpci->buildPath;
         $this->filename     = isset($options['filename']) ? $options['filename'] : 'build';
         $this->format       = isset($options['format']) ?  $options['format'] : 'zip';
     }

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -92,7 +92,7 @@ class Pdepend extends AbstractPlugin
         $config = $this->phpci->getSystemConfig('phpci');
 
         if ($success) {
-            $this->phpci->logSuccess(
+            $this->logger->logSuccess(
                 sprintf(
                     "Pdepend successful. You can use %s\n, ![Chart](%s \"Pdepend Chart\")\n
                     and ![Pyramid](%s \"Pdepend Pyramid\")\n

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Pdepend extends AbstractPlugin
+class Pdepend extends AbstractExecutingPlugin
 {
     protected $args;
     /**
@@ -67,7 +67,7 @@ class Pdepend extends AbstractPlugin
             throw new \Exception(sprintf('The location %s is not writable.', $this->location));
         }
 
-        $pdepend = $this->phpci->findBinary('pdepend');
+        $pdepend = $this->executor->findBinary('pdepend');
 
         $cmd = $pdepend . ' --summary-xml="%s" --jdepend-chart="%s" --overview-pyramid="%s" %s "%s"';
 
@@ -80,7 +80,7 @@ class Pdepend extends AbstractPlugin
             $ignore = '';
         }
 
-        $success = $this->phpci->executeCommand(
+        $success = $this->executor->executeCommand(
             $cmd,
             $this->location . DIRECTORY_SEPARATOR . $this->summary,
             $this->location . DIRECTORY_SEPARATOR . $this->chart,

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -74,8 +74,8 @@ class Pdepend extends AbstractExecutingPlugin
         $this->removeBuildArtifacts();
 
         // If we need to ignore directories
-        if (count($this->phpci->ignore)) {
-            $ignore = ' --ignore=' . implode(',', $this->phpci->ignore);
+        if (count($this->ignore)) {
+            $ignore = ' --ignore=' . implode(',', $this->ignore);
         } else {
             $ignore = '';
         }

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -49,13 +49,13 @@ class Pdepend extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->directory = isset($options['directory']) ? $options['directory'] : $this->phpci->buildPath;
+        $this->directory = isset($options['directory']) ? $options['directory'] : $this->buildPath;
 
         $title = $this->phpci->getBuildProjectTitle();
         $this->summary  = $title . '-summary.xml';
         $this->pyramid  = $title . '-pyramid.svg';
         $this->chart    = $title . '-chart.svg';
-        $this->location = $this->phpci->buildPath . '..' . DIRECTORY_SEPARATOR . 'pdepend';
+        $this->location = $this->buildPath . '..' . DIRECTORY_SEPARATOR . 'pdepend';
     }
 
     /**

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -92,7 +92,7 @@ class Pdepend extends AbstractExecutingPlugin
         $config = $this->phpci->getSystemConfig('phpci');
 
         if ($success) {
-            $this->logger->logSuccess(
+            $this->logger->notice(
                 sprintf(
                     "Pdepend successful. You can use %s\n, ![Chart](%s \"Pdepend Chart\")\n
                     and ![Pyramid](%s \"Pdepend Pyramid\")\n

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -19,13 +19,9 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Pdepend implements \PHPCI\Plugin
+class Pdepend extends AbstractPlugin
 {
     protected $args;
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
     /**
      * @var string Directory which needs to be scanned
      */
@@ -56,8 +52,7 @@ class Pdepend implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         $this->directory = isset($options['directory']) ? $options['directory'] : $phpci->buildPath;
 

--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * Pdepend Plugin - Allows Pdepend report
@@ -45,18 +43,15 @@ class Pdepend extends AbstractPlugin
     protected $location;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
+        $this->directory = isset($options['directory']) ? $options['directory'] : $this->phpci->buildPath;
 
-        $this->directory = isset($options['directory']) ? $options['directory'] : $phpci->buildPath;
-
-        $title = $phpci->getBuildProjectTitle();
+        $title = $this->phpci->getBuildProjectTitle();
         $this->summary  = $title . '-summary.xml';
         $this->pyramid  = $title . '-pyramid.svg';
         $this->chart    = $title . '-chart.svg';

--- a/PHPCI/Plugin/Pgsql.php
+++ b/PHPCI/Plugin/Pgsql.php
@@ -47,15 +47,16 @@ class Pgsql extends AbstractInterpolatingPlugin
     protected function setOptions(array $options)
     {
         $this->queries = $options;
+    }
 
-        $buildSettings = $this->phpci->getConfig('build_settings');
-
-        if (isset($buildSettings['pgsql'])) {
-            $sql = $buildSettings['pgsql'];
-            $this->host = $sql['host'];
-            $this->user = $sql['user'];
-            $this->pass = $sql['pass'];
-        }
+    /**
+     * {@inheritdoc}
+     */
+    protected function setCommonSettings(array $settings)
+    {
+        $this->host = $settings['host'];
+        $this->user = $settings['user'];
+        $this->pass = $settings['pass'];
     }
 
     /**

--- a/PHPCI/Plugin/Pgsql.php
+++ b/PHPCI/Plugin/Pgsql.php
@@ -17,7 +17,7 @@ use PDO;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Pgsql extends AbstractPlugin
+class Pgsql extends AbstractInterpolatingPlugin
 {
     /**
      * @var array
@@ -69,7 +69,7 @@ class Pgsql extends AbstractPlugin
             $pdo = new PDO('pgsql:host=' . $this->host, $this->user, $this->pass, $opts);
 
             foreach ($this->queries as $query) {
-                $pdo->query($this->phpci->interpolate($query));
+                $pdo->query($this->interpolator->interpolate($query));
             }
         } catch (\Exception $ex) {
             $this->logger->logFailure($ex->getMessage());

--- a/PHPCI/Plugin/Pgsql.php
+++ b/PHPCI/Plugin/Pgsql.php
@@ -65,16 +65,11 @@ class Pgsql extends AbstractInterpolatingPlugin
     */
     public function execute()
     {
-        try {
-            $opts = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
-            $pdo = new PDO('pgsql:host=' . $this->host, $this->user, $this->pass, $opts);
+        $opts = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
+        $pdo = new PDO('pgsql:host=' . $this->host, $this->user, $this->pass, $opts);
 
-            foreach ($this->queries as $query) {
-                $pdo->query($this->interpolator->interpolate($query));
-            }
-        } catch (\Exception $ex) {
-            $this->logger->logFailure($ex->getMessage());
-            return false;
+        foreach ($this->queries as $query) {
+            $pdo->query($this->interpolator->interpolate($query));
         }
         return true;
     }

--- a/PHPCI/Plugin/Pgsql.php
+++ b/PHPCI/Plugin/Pgsql.php
@@ -10,8 +10,6 @@
 namespace PHPCI\Plugin;
 
 use PDO;
-use PHPCI\Builder;
-use PHPCI\Model\Build;
 
 /**
 * PgSQL Plugin - Provides access to a PgSQL database.
@@ -42,17 +40,15 @@ class Pgsql extends AbstractPlugin
     protected $pass;
 
     /**
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * Configure the plugin.
+     *
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->queries = $options;
 
-        $buildSettings = $phpci->getConfig('build_settings');
+        $buildSettings = $this->phpci->getConfig('build_settings');
 
         if (isset($buildSettings['pgsql'])) {
             $sql = $buildSettings['pgsql'];

--- a/PHPCI/Plugin/Pgsql.php
+++ b/PHPCI/Plugin/Pgsql.php
@@ -72,7 +72,7 @@ class Pgsql extends AbstractPlugin
                 $pdo->query($this->phpci->interpolate($query));
             }
         } catch (\Exception $ex) {
-            $this->phpci->logFailure($ex->getMessage());
+            $this->logger->logFailure($ex->getMessage());
             return false;
         }
         return true;

--- a/PHPCI/Plugin/Pgsql.php
+++ b/PHPCI/Plugin/Pgsql.php
@@ -19,18 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Pgsql implements \PHPCI\Plugin
+class Pgsql extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     /**
      * @var array
      */
@@ -58,8 +48,8 @@ class Pgsql implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci   = $phpci;
-        $this->build   = $build;
+        parent::__construct($phpci, $build);
+
         $this->queries = $options;
 
         $buildSettings = $phpci->getConfig('build_settings');

--- a/PHPCI/Plugin/Phar.php
+++ b/PHPCI/Plugin/Phar.php
@@ -10,20 +10,8 @@ use Phar as PHPPhar;
 /**
  * Phar Plugin
  */
-class Phar implements \PHPCI\Plugin
+class Phar extends AbstractPlugin
 {
-    /**
-     * PHPCI
-     * @var Builder
-     */
-    protected $phpci;
-
-    /**
-     * Build
-     * @var Build
-     */
-    protected $build;
-
     /**
      * Output Directory
      * @var string
@@ -62,9 +50,7 @@ class Phar implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        // Basic
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         // Directory?
         if (isset($options['directory'])) {

--- a/PHPCI/Plugin/Phar.php
+++ b/PHPCI/Plugin/Phar.php
@@ -236,7 +236,6 @@ class Phar implements \PHPCI\Plugin
             }
 
             $success = true;
-
         } catch (Exception $e) {
             $this->getPHPCI()->log(Lang::get('phar_internal_error'));
             $this->getPHPCI()->log($e->getMessage());

--- a/PHPCI/Plugin/Phar.php
+++ b/PHPCI/Plugin/Phar.php
@@ -200,23 +200,14 @@ class Phar extends AbstractPlugin
      */
     public function execute()
     {
-        $success = false;
+        $phar = new PHPPhar($this->getDirectory() . '/' . $this->getFilename(), 0, $this->getFilename());
+        $phar->buildFromDirectory($this->getPHPCI()->buildPath, $this->getRegExp());
 
-        try {
-            $phar = new PHPPhar($this->getDirectory() . '/' . $this->getFilename(), 0, $this->getFilename());
-            $phar->buildFromDirectory($this->getPHPCI()->buildPath, $this->getRegExp());
-
-            $stub = $this->getStubContent();
-            if ($stub) {
-                $phar->setStub($stub);
-            }
-
-            $success = true;
-        } catch (Exception $e) {
-            $this->getPHPCI()->log(Lang::get('phar_internal_error'));
-            $this->getPHPCI()->log($e->getMessage());
+        $stub = $this->getStubContent();
+        if ($stub) {
+            $phar->setStub($stub);
         }
 
-        return $success;
+        return true;
     }
 }

--- a/PHPCI/Plugin/Phar.php
+++ b/PHPCI/Plugin/Phar.php
@@ -2,7 +2,6 @@
 namespace PHPCI\Plugin;
 
 use Exception;
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
 use PHPCI\Model\Build;
 use Phar as PHPPhar;
@@ -37,21 +36,12 @@ class Phar extends AbstractPlugin
     protected $stub;
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         // Directory?
         if (isset($options['directory'])) {
             $this->setDirectory($options['directory']);

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -21,15 +21,11 @@ use PHPCI\Helper\Lang;
  */
 class Phing extends AbstractExecutingPlugin
 {
-
     private $directory;
     private $buildFile = 'build.xml';
     private $targets = array('build');
     private $properties = array();
     private $propertyFile;
-
-    protected $phpci;
-    protected $build;
 
     /**
      * Configure the plugin.
@@ -89,14 +85,6 @@ class Phing extends AbstractExecutingPlugin
         $cmd[] = '2>&1';
 
         return $this->executor->executeCommand(implode(' ', $cmd), $this->directory, $this->targets);
-    }
-
-    /**
-     * @return Builder
-     */
-    public function getPhpci()
-    {
-        return $this->phpci;
     }
 
     /**

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -42,9 +42,9 @@ class Phing extends AbstractPlugin
          * Set working directory
          */
         if (isset($options['directory'])) {
-            $directory = $phpci->buildPath . '/' . $options['directory'];
+            $directory = $buildPath . '/' . $options['directory'];
         } else {
-            $directory = $phpci->buildPath;
+            $directory = $buildPath;
         }
 
         $this->setDirectory($directory);

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -20,7 +20,7 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Phing implements \PHPCI\Plugin
+class Phing extends AbstractPlugin
 {
 
     private $directory;
@@ -40,8 +40,7 @@ class Phing implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->setPhpci($phpci);
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         /*
          * Set working directory
@@ -102,16 +101,6 @@ class Phing implements \PHPCI\Plugin
     public function getPhpci()
     {
         return $this->phpci;
-    }
-
-    /**
-     * @param \PHPCI\Builder $phpci
-     *
-     * @return $this
-     */
-    public function setPhpci($phpci)
-    {
-        $this->phpci = $phpci;
     }
 
     /**

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -11,7 +11,6 @@ namespace PHPCI\Plugin;
 
 use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * Phing Plugin - Provides access to Phing functionality.
@@ -33,15 +32,12 @@ class Phing extends AbstractPlugin
     protected $build;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         /*
          * Set working directory
          */
@@ -96,7 +92,7 @@ class Phing extends AbstractPlugin
     }
 
     /**
-     * @return \PHPCI\Builder
+     * @return Builder
      */
     public function getPhpci()
     {

--- a/PHPCI/Plugin/Phing.php
+++ b/PHPCI/Plugin/Phing.php
@@ -19,7 +19,7 @@ use PHPCI\Helper\Lang;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Phing extends AbstractPlugin
+class Phing extends AbstractExecutingPlugin
 {
 
     private $directory;
@@ -74,7 +74,7 @@ class Phing extends AbstractPlugin
      */
     public function execute()
     {
-        $phingExecutable = $this->phpci->findBinary('phing');
+        $phingExecutable = $this->executor->findBinary('phing');
 
         $cmd[] = $phingExecutable . ' -f ' . $this->getBuildFilePath();
 
@@ -88,7 +88,7 @@ class Phing extends AbstractPlugin
         $cmd[] = $this->targetsToString();
         $cmd[] = '2>&1';
 
-        return $this->phpci->executeCommand(implode(' ', $cmd), $this->directory, $this->targets);
+        return $this->executor->executeCommand(implode(' ', $cmd), $this->directory, $this->targets);
     }
 
     /**

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -84,16 +84,14 @@ class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     }
 
     /**
-     * @param \PHPCI\Builder $phpci
-     * @param \PHPCI\Model\Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->suffixes = array('php');
-        $this->directory = $phpci->buildPath;
+        $this->directory = $this->phpci->buildPath;
         $this->standard = 'PSR2';
         $this->tab_width = '';
         $this->encoding = '';
@@ -119,15 +117,6 @@ class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $this->encoding = ' --encoding=' . $options['encoding'];
         }
 
-        $this->setOptions($options);
-    }
-
-    /**
-     * Handle this plugin's options.
-     * @param $options
-     */
-    protected function setOptions($options)
-    {
         foreach (array('directory', 'standard', 'path', 'ignore', 'allowed_warnings', 'allowed_errors') as $key) {
             if (array_key_exists($key, $options)) {
                 $this->{$key} = $options[$key];

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -19,7 +19,7 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
+class PhpCodeSniffer extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlugin
 {
     /**
      * @var array
@@ -131,12 +131,12 @@ class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     {
         list($ignore, $standard, $suffixes) = $this->getFlags();
 
-        $phpcs = $this->phpci->findBinary('phpcs');
+        $phpcs = $this->executor->findBinary('phpcs');
 
-        $this->phpci->logExecOutput(false);
+        $this->executor->setQuiet(true);
 
         $cmd = $phpcs . ' --report=json %s %s %s %s %s "%s"';
-        $this->phpci->executeCommand(
+        $this->executor->executeCommand(
             $cmd,
             $standard,
             $suffixes,
@@ -146,10 +146,10 @@ class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $this->buildPath . $this->path
         );
 
-        $output = $this->phpci->getLastOutput();
+        $output = $this->executor->getLastOutput();
         list($errors, $warnings, $data) = $this->processReport($output);
 
-        $this->phpci->logExecOutput(true);
+        $this->executor->setQuiet(false);
 
         $success = true;
         $this->build->storeMeta('phpcs-warnings', $warnings);

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -197,7 +197,7 @@ class PhpCodeSniffer extends AbstractExecutingPlugin implements PHPCI\ZeroConfig
         $data = json_decode(trim($output), true);
 
         if (!is_array($data)) {
-            $this->logger->log($output);
+            $this->logger->error($output);
             throw new \Exception(PHPCI\Helper\Lang::get('could_not_process_report'));
         }
 

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -63,11 +63,6 @@ class PhpCodeSniffer extends AbstractExecutingPlugin implements PHPCI\ZeroConfig
     protected $path;
 
     /**
-     * @var array - paths to ignore
-     */
-    protected $ignore;
-
-    /**
      * Check if this plugin can be executed.
      * @param $stage
      * @param Builder $builder
@@ -96,7 +91,6 @@ class PhpCodeSniffer extends AbstractExecutingPlugin implements PHPCI\ZeroConfig
         $this->tab_width = '';
         $this->encoding = '';
         $this->path = '';
-        $this->ignore = $this->phpci->ignore;
         $this->allowed_warnings = 0;
         $this->allowed_errors = 0;
 

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -19,13 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpCodeSniffer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
+class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
     /**
      * @var array
      */
@@ -95,8 +90,8 @@ class PhpCodeSniffer implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->suffixes = array('php');
         $this->directory = $phpci->buildPath;
         $this->standard = 'PSR2';

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -203,7 +203,7 @@ class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         $data = json_decode(trim($output), true);
 
         if (!is_array($data)) {
-            $this->phpci->log($output);
+            $this->logger->log($output);
             throw new \Exception(PHPCI\Helper\Lang::get('could_not_process_report'));
         }
 

--- a/PHPCI/Plugin/PhpCodeSniffer.php
+++ b/PHPCI/Plugin/PhpCodeSniffer.php
@@ -91,7 +91,7 @@ class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     protected function setOptions(array $options)
     {
         $this->suffixes = array('php');
-        $this->directory = $this->phpci->buildPath;
+        $this->directory = $this->buildPath;
         $this->standard = 'PSR2';
         $this->tab_width = '';
         $this->encoding = '';
@@ -143,7 +143,7 @@ class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $ignore,
             $this->tab_width,
             $this->encoding,
-            $this->phpci->buildPath . $this->path
+            $this->buildPath . $this->path
         );
 
         $output = $this->phpci->getLastOutput();
@@ -213,7 +213,7 @@ class PhpCodeSniffer extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         $rtn = array();
 
         foreach ($data['files'] as $fileName => $file) {
-            $fileName = str_replace($this->phpci->buildPath, '', $fileName);
+            $fileName = str_replace($this->buildPath, '', $fileName);
 
             foreach ($file['messages'] as $message) {
                 $this->build->reportError($this->phpci, $fileName, $message['line'], 'PHPCS: ' . $message['message']);

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -19,12 +19,10 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpCpd implements \PHPCI\Plugin
+class PhpCpd extends AbstractPlugin
 {
     protected $directory;
     protected $args;
-    protected $phpci;
-    protected $build;
 
     /**
      * @var string, based on the assumption the root may not hold the code to be
@@ -45,8 +43,7 @@ class PhpCpd implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         $this->path = $phpci->buildPath;
         $this->standard = 'PSR1';

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -40,12 +40,12 @@ class PhpCpd extends AbstractExecutingPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->path = $buildPath;
+        $this->path = $this->buildPath;
         $this->standard = 'PSR1';
-        $this->ignore = $phpci->ignore;
+        $this->ignore = $this->phpci->ignore;
 
         if (!empty($options['path'])) {
-            $this->path = $buildPath . $options['path'];
+            $this->path = $this->buildPath . $options['path'];
         }
 
         if (!empty($options['standard'])) {

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -145,7 +145,6 @@ Copy and paste detected:
 CPD;
 
                 $this->build->reportError($this->phpci, $fileName, $file['line'], $message);
-
             }
 
             $warnings++;

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpCpd extends AbstractPlugin
+class PhpCpd extends AbstractExecutingPlugin
 {
     protected $directory;
     protected $args;
@@ -80,14 +80,14 @@ class PhpCpd extends AbstractPlugin
             $ignore = implode('', $ignore);
         }
 
-        $phpcpd = $this->phpci->findBinary('phpcpd');
+        $phpcpd = $this->executor->findBinary('phpcpd');
 
         $tmpfilename = tempnam('/tmp', 'phpcpd');
 
         $cmd = $phpcpd . ' --log-pmd "%s" %s "%s"';
-        $success = $this->phpci->executeCommand($cmd, $tmpfilename, $ignore, $this->path);
+        $success = $this->executor->executeCommand($cmd, $tmpfilename, $ignore, $this->path);
 
-        print $this->phpci->getLastOutput();
+        print $this->executor->getLastOutput();
 
         list($errorCount, $data) = $this->processReport(file_get_contents($tmpfilename));
         $this->build->storeMeta('phpcpd-warnings', $errorCount);

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -109,7 +109,7 @@ class PhpCpd extends AbstractPlugin
         $xml = simplexml_load_string($xmlString);
 
         if ($xml === false) {
-            $this->phpci->log($xmlString);
+            $this->logger->log($xmlString);
             throw new \Exception(Lang::get('could_not_process_report'));
         }
 

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
 * PHP Copy / Paste Detector - Allows PHP Copy / Paste Detector testing.
@@ -36,15 +34,12 @@ class PhpCpd extends AbstractPlugin
     protected $ignore;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->path = $phpci->buildPath;
         $this->standard = 'PSR1';
         $this->ignore = $phpci->ignore;

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -103,7 +103,7 @@ class PhpCpd extends AbstractExecutingPlugin
         $xml = simplexml_load_string($xmlString);
 
         if ($xml === false) {
-            $this->logger->log($xmlString);
+            $this->logger->error($xmlString);
             throw new \Exception(Lang::get('could_not_process_report'));
         }
 

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -29,11 +29,6 @@ class PhpCpd extends AbstractExecutingPlugin
     protected $path;
 
     /**
-     * @var array - paths to ignore
-     */
-    protected $ignore;
-
-    /**
      * Configure the plugin.
      *
      * @param array $options
@@ -42,7 +37,6 @@ class PhpCpd extends AbstractExecutingPlugin
     {
         $this->path = $this->buildPath;
         $this->standard = 'PSR1';
-        $this->ignore = $this->phpci->ignore;
 
         if (!empty($options['path'])) {
             $this->path = $this->buildPath . $options['path'];

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -40,12 +40,12 @@ class PhpCpd extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->path = $phpci->buildPath;
+        $this->path = $buildPath;
         $this->standard = 'PSR1';
         $this->ignore = $phpci->ignore;
 
         if (!empty($options['path'])) {
-            $this->path = $phpci->buildPath . $options['path'];
+            $this->path = $buildPath . $options['path'];
         }
 
         if (!empty($options['standard'])) {
@@ -119,7 +119,7 @@ class PhpCpd extends AbstractPlugin
         foreach ($xml->duplication as $duplication) {
             foreach ($duplication->file as $file) {
                 $fileName = (string)$file['path'];
-                $fileName = str_replace($this->phpci->buildPath, '', $fileName);
+                $fileName = str_replace($this->buildPath, '', $fileName);
 
                 $data[] = array(
                     'file' => $fileName,

--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -98,6 +98,5 @@ class PhpCsFixer implements \PHPCI\Plugin
         if (isset($options['workingdir']) && $options['workingdir']) {
             $this->workingdir = $this->phpci->buildPath . $options['workingdir'];
         }
-
     }
 }

--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
 * PHP CS Fixer - Works with the PHP CS Fixer for testing coding standards.
@@ -28,23 +26,29 @@ class PhpCsFixer extends AbstractPlugin
     protected $levels     = array('psr0', 'psr1', 'psr2', 'all');
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->workingdir = $this->phpci->buildPath;
-        $this->buildArgs($options);
+
+        if (isset($options['verbose']) && $options['verbose']) {
+            $this->verbose = ' --verbose';
+        }
+
+        if (isset($options['diff']) && $options['diff']) {
+            $this->diff = ' --diff';
+        }
+
+        if (isset($options['level']) && in_array($options['level'], $this->levels)) {
+            $this->level = ' --level='.$options['level'];
+        }
+
+        if (isset($options['workingdir']) && $options['workingdir']) {
+            $this->workingdir .= $options['workingdir'];
+        }
     }
 
     /**
@@ -64,28 +68,5 @@ class PhpCsFixer extends AbstractPlugin
         chdir($curdir);
 
         return $success;
-    }
-
-    /**
-     * Build an args string for PHPCS Fixer.
-     * @param $options
-     */
-    public function buildArgs($options)
-    {
-        if (isset($options['verbose']) && $options['verbose']) {
-            $this->verbose = ' --verbose';
-        }
-
-        if (isset($options['diff']) && $options['diff']) {
-            $this->diff = ' --diff';
-        }
-
-        if (isset($options['level']) && in_array($options['level'], $this->levels)) {
-            $this->level = ' --level='.$options['level'];
-        }
-
-        if (isset($options['workingdir']) && $options['workingdir']) {
-            $this->workingdir = $this->phpci->buildPath . $options['workingdir'];
-        }
     }
 }

--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -19,18 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpCsFixer implements \PHPCI\Plugin
+class PhpCsFixer extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     protected $workingDir = '';
     protected $level      = ' --level=all';
     protected $verbose    = '';
@@ -51,8 +41,7 @@ class PhpCsFixer implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         $this->workingdir = $this->phpci->buildPath;
         $this->buildArgs($options);

--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpCsFixer extends AbstractPlugin
+class PhpCsFixer extends AbstractExecutingPlugin
 {
     protected $workingDir = '';
     protected $level      = ' --level=all';
@@ -60,10 +60,10 @@ class PhpCsFixer extends AbstractPlugin
         $curdir = getcwd();
         chdir($this->workingdir);
 
-        $phpcsfixer = $this->phpci->findBinary('php-cs-fixer');
+        $phpcsfixer = $this->executor->findBinary('php-cs-fixer');
 
         $cmd = $phpcsfixer . ' fix . %s %s %s';
-        $success = $this->phpci->executeCommand($cmd, $this->verbose, $this->diff, $this->level);
+        $success = $this->executor->executeCommand($cmd, $this->verbose, $this->diff, $this->level);
 
         chdir($curdir);
 

--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -32,7 +32,7 @@ class PhpCsFixer extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->workingdir = $this->phpci->buildPath;
+        $this->workingdir = $this->buildPath;
 
         if (isset($options['verbose']) && $options['verbose']) {
             $this->verbose = ' --verbose';

--- a/PHPCI/Plugin/PhpDocblockChecker.php
+++ b/PHPCI/Plugin/PhpDocblockChecker.php
@@ -19,7 +19,7 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpDocblockChecker extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
+class PhpDocblockChecker extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlugin
 {
     /**
      * @var string Based on the assumption the root may not hold the code to be
@@ -89,7 +89,7 @@ class PhpDocblockChecker extends AbstractPlugin implements PHPCI\ZeroConfigPlugi
     public function execute()
     {
         // Check that the binary exists:
-        $checker = $this->phpci->findBinary('phpdoccheck');
+        $checker = $this->executor->findBinary('phpdoccheck');
 
         // Build ignore string:
         $ignore = '';
@@ -112,10 +112,10 @@ class PhpDocblockChecker extends AbstractPlugin implements PHPCI\ZeroConfigPlugi
         $cmd = $checker . ' --json --directory="%s"%s%s';
 
         // Disable exec output logging, as we don't want the XML report in the log:
-        $this->phpci->logExecOutput(false);
+        $this->executor->setQuiet(true);
 
         // Run checker:
-        $this->phpci->executeCommand(
+        $this->executor->executeCommand(
             $cmd,
             $path,
             $ignore,
@@ -123,9 +123,9 @@ class PhpDocblockChecker extends AbstractPlugin implements PHPCI\ZeroConfigPlugi
         );
 
         // Re-enable exec output logging:
-        $this->phpci->logExecOutput(true);
+        $this->executor->setQuiet(false);
 
-        $output = json_decode($this->phpci->getLastOutput(), true);
+        $output = json_decode($this->executor->getLastOutput(), true);
         $errors = count($output);
         $success = true;
 

--- a/PHPCI/Plugin/PhpDocblockChecker.php
+++ b/PHPCI/Plugin/PhpDocblockChecker.php
@@ -19,18 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpDocblockChecker implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
+class PhpDocblockChecker extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     /**
      * @var string Based on the assumption the root may not hold the code to be
      * tested, extends the build path.
@@ -69,8 +59,8 @@ class PhpDocblockChecker implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->ignore = $phpci->ignore;
         $this->path = '';
         $this->allowed_warnings = 0;

--- a/PHPCI/Plugin/PhpDocblockChecker.php
+++ b/PHPCI/Plugin/PhpDocblockChecker.php
@@ -27,11 +27,6 @@ class PhpDocblockChecker extends AbstractExecutingPlugin implements PHPCI\ZeroCo
      */
     protected $path;
 
-    /**
-     * @var array - paths to ignore
-     */
-    protected $ignore;
-
     protected $skipClasses = false;
     protected $skipMethods = false;
 
@@ -58,7 +53,6 @@ class PhpDocblockChecker extends AbstractExecutingPlugin implements PHPCI\ZeroCo
      */
     protected function setOptions(array $options)
     {
-        $this->ignore = $this->phpci->ignore;
         $this->path = '';
         $this->allowed_warnings = 0;
 

--- a/PHPCI/Plugin/PhpDocblockChecker.php
+++ b/PHPCI/Plugin/PhpDocblockChecker.php
@@ -108,7 +108,7 @@ class PhpDocblockChecker extends AbstractPlugin implements PHPCI\ZeroConfigPlugi
         }
 
         // Build command string:
-        $path = $this->phpci->buildPath . $this->path;
+        $path = $this->buildPath . $this->path;
         $cmd = $checker . ' --json --directory="%s"%s%s';
 
         // Disable exec output logging, as we don't want the XML report in the log:

--- a/PHPCI/Plugin/PhpDocblockChecker.php
+++ b/PHPCI/Plugin/PhpDocblockChecker.php
@@ -52,16 +52,13 @@ class PhpDocblockChecker extends AbstractPlugin implements PHPCI\ZeroConfigPlugi
     }
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $this->ignore = $phpci->ignore;
+        $this->ignore = $this->phpci->ignore;
         $this->path = '';
         $this->allowed_warnings = 0;
 

--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -19,7 +19,7 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class PhpLoc extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
+class PhpLoc extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlugin
 {
     /**
      * Check if this plugin can be executed.
@@ -66,10 +66,10 @@ class PhpLoc extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $ignore = implode('', $ignore);
         }
 
-        $phploc = $this->phpci->findBinary('phploc');
+        $phploc = $this->executor->findBinary('phploc');
 
-        $success = $this->phpci->executeCommand($phploc . ' %s "%s"', $ignore, $this->directory);
-        $output = $this->phpci->getLastOutput();
+        $success = $this->executor->executeCommand($phploc . ' %s "%s"', $ignore, $this->directory);
+        $output = $this->executor->getLastOutput();
 
         if (preg_match_all('/\((LOC|CLOC|NCLOC|LLOC)\)\s+([0-9]+)/', $output, $matches)) {
             $data = array();

--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -19,17 +19,8 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
+class PhpLoc extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 {
-    /**
-     * @var string
-     */
-    protected $directory;
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
     /**
      * Check if this plugin can be executed.
      * @param $stage
@@ -54,8 +45,8 @@ class PhpLoc implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci     = $phpci;
-        $this->build     = $build;
+        parent::__construct($phpci, $build);
+
         $this->directory = $phpci->buildPath;
 
         if (isset($options['directory'])) {

--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -38,16 +38,13 @@ class PhpLoc extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     }
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $this->directory = $phpci->buildPath;
+        $this->directory = $this->phpci->buildPath;
 
         if (isset($options['directory'])) {
             $this->directory .= $options['directory'];

--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -44,7 +44,7 @@ class PhpLoc extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->directory = $this->phpci->buildPath;
+        $this->directory = $this->buildPath;
 
         if (isset($options['directory'])) {
             $this->directory .= $options['directory'];

--- a/PHPCI/Plugin/PhpLoc.php
+++ b/PHPCI/Plugin/PhpLoc.php
@@ -57,11 +57,11 @@ class PhpLoc extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlugin
     public function execute()
     {
         $ignore = '';
-        if (count($this->phpci->ignore)) {
+        if (count($this->ignore)) {
             $map    = function ($item) {
                 return ' --exclude ' . (substr($item, -1) == '/' ? substr($item, 0, -1) : $item);
             };
-            $ignore = array_map($map, $this->phpci->ignore);
+            $ignore = array_map($map, $this->ignore);
 
             $ignore = implode('', $ignore);
         }

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -172,8 +172,7 @@ class PhpMessDetector extends AbstractExecutingPlugin implements PHPCI\ZeroConfi
     protected function tryAndProcessRules()
     {
         if (!empty($this->rules) && !is_array($this->rules)) {
-            $this->phpci->logFailure('The "rules" option must be an array.');
-            return false;
+            throw new \Exception('The "rules" option must be an array.');
         }
 
         foreach ($this->rules as &$rule) {

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -34,11 +34,6 @@ class PhpMessDetector extends AbstractExecutingPlugin implements PHPCI\ZeroConfi
     protected $path;
 
     /**
-     * @var array - paths to ignore
-     */
-    protected $ignore;
-
-    /**
      * Array of PHPMD rules. Can be one of the builtins (codesize, unusedcode, naming, design, controversial)
      * or a filenname (detected by checking for a / in it), either absolute or relative to the project root.
      * @var array
@@ -69,7 +64,6 @@ class PhpMessDetector extends AbstractExecutingPlugin implements PHPCI\ZeroConfi
     protected function setOptions(array $options)
     {
         $this->suffixes = array('php');
-        $this->ignore = $this->phpci->ignore;
         $this->path = '';
         $this->rules = array('codesize', 'unusedcode', 'naming');
         $this->allowed_warnings = 0;

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -143,7 +143,7 @@ class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 
         foreach ($xml->file as $file) {
             $fileName = (string)$file['name'];
-            $fileName = str_replace($this->phpci->buildPath, '', $fileName);
+            $fileName = str_replace($this->buildPath, '', $fileName);
 
             foreach ($file->violation as $violation) {
                 $warnings++;
@@ -178,7 +178,7 @@ class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 
         foreach ($this->rules as &$rule) {
             if (strpos($rule, '/') !== false) {
-                $rule = $this->phpci->buildPath . $rule;
+                $rule = $this->buildPath . $rule;
             }
         }
 
@@ -227,7 +227,7 @@ class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
      */
     protected function getTargetPath()
     {
-        $path = $this->phpci->buildPath . $this->path;
+        $path = $this->buildPath . $this->path;
         if (!empty($this->path) && $this->path{0} == '/') {
             $path = $this->path;
             return $path;

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -62,23 +62,14 @@ class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     }
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->suffixes = array('php');
-        $this->ignore = $phpci->ignore;
+        $this->ignore = $this->phpci->ignore;
         $this->path = '';
         $this->rules = array('codesize', 'unusedcode', 'naming');
         $this->allowed_warnings = 0;

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -19,18 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpMessDetector implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
+class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     /**
      * @var array
      */
@@ -85,8 +75,8 @@ class PhpMessDetector implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->suffixes = array('php');
         $this->ignore = $phpci->ignore;
         $this->path = '';

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -128,7 +128,7 @@ class PhpMessDetector extends AbstractExecutingPlugin implements PHPCI\ZeroConfi
         $xml = simplexml_load_string($xmlString);
 
         if ($xml === false) {
-            $this->logger->log($xmlString);
+            $this->logger->error($xmlString);
             throw new \Exception('Could not process PHPMD report XML.');
         }
 

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -134,7 +134,7 @@ class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         $xml = simplexml_load_string($xmlString);
 
         if ($xml === false) {
-            $this->phpci->log($xmlString);
+            $this->logger->log($xmlString);
             throw new \Exception('Could not process PHPMD report XML.');
         }
 

--- a/PHPCI/Plugin/PhpMessDetector.php
+++ b/PHPCI/Plugin/PhpMessDetector.php
@@ -19,7 +19,7 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
+class PhpMessDetector extends AbstractExecutingPlugin implements PHPCI\ZeroConfigPlugin
 {
     /**
      * @var array
@@ -100,11 +100,11 @@ class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             return false;
         }
 
-        $phpmdBinaryPath = $this->phpci->findBinary('phpmd');
+        $phpmdBinaryPath = $this->executor->findBinary('phpmd');
 
         $this->executePhpMd($phpmdBinaryPath);
 
-        list($errorCount, $data) = $this->processReport(trim($this->phpci->getLastOutput()));
+        list($errorCount, $data) = $this->processReport(trim($this->executor->getLastOutput()));
         $this->build->storeMeta('phpmd-warnings', $errorCount);
         $this->build->storeMeta('phpmd-data', $data);
 
@@ -206,10 +206,10 @@ class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         }
 
         // Disable exec output logging, as we don't want the XML report in the log:
-        $this->phpci->logExecOutput(false);
+        $this->executor->setQuiet(true);
 
         // Run PHPMD:
-        $this->phpci->executeCommand(
+        $this->executor->executeCommand(
             $cmd,
             $path,
             implode(',', $this->rules),
@@ -218,7 +218,7 @@ class PhpMessDetector extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         );
 
         // Re-enable exec output logging:
-        $this->phpci->logExecOutput(true);
+        $this->executor->setQuiet(false);
     }
 
     /**

--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -36,11 +36,11 @@ class PhpParallelLint extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->directory    = $phpci->buildPath;
+        $this->directory    = $buildPath;
         $this->ignore       = $this->phpci->ignore;
 
         if (isset($options['directory'])) {
-            $this->directory = $phpci->buildPath.$options['directory'];
+            $this->directory = $buildPath.$options['directory'];
         }
 
         if (isset($options['ignore'])) {
@@ -82,7 +82,7 @@ class PhpParallelLint extends AbstractPlugin
     {
         $ignoreFlags = array();
         foreach ($this->ignore as $ignoreDir) {
-            $ignoreFlags[] = '--exclude "' . $this->phpci->buildPath . $ignoreDir . '"';
+            $ignoreFlags[] = '--exclude "' . $this->buildPath . $ignoreDir . '"';
         }
         $ignore = implode(' ', $ignoreFlags);
 

--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
 * Php Parallel Lint Plugin - Provides access to PHP lint functionality.
@@ -32,21 +30,12 @@ class PhpParallelLint extends AbstractPlugin
     protected $ignore;
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->directory    = $phpci->buildPath;
         $this->ignore       = $this->phpci->ignore;
 

--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpParallelLint extends AbstractPlugin
+class PhpParallelLint extends AbstractExecutingPlugin
 {
     /**
      * @var string
@@ -55,16 +55,16 @@ class PhpParallelLint extends AbstractPlugin
     {
         list($ignore) = $this->getFlags();
 
-        $phplint = $this->phpci->findBinary('parallel-lint');
+        $phplint = $this->executor->findBinary('parallel-lint');
 
         $cmd = $phplint . ' %s "%s"';
-        $success = $this->phpci->executeCommand(
+        $success = $this->executor->executeCommand(
             $cmd,
             $ignore,
             $this->directory
         );
 
-        $output = $this->phpci->getLastOutput();
+        $output = $this->executor->getLastOutput();
 
         $matches = array();
         if (preg_match_all('/Parse error\:/', $output, $matches)) {

--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -25,11 +25,6 @@ class PhpParallelLint extends AbstractExecutingPlugin
     protected $directory;
 
     /**
-     * @var array - paths to ignore
-     */
-    protected $ignore;
-
-    /**
      * Configure the plugin.
      *
      * @param array $options
@@ -37,7 +32,6 @@ class PhpParallelLint extends AbstractExecutingPlugin
     protected function setOptions(array $options)
     {
         $this->directory    = $buildPath;
-        $this->ignore       = $this->phpci->ignore;
 
         if (isset($options['directory'])) {
             $this->directory = $buildPath.$options['directory'];

--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -19,18 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpParallelLint implements \PHPCI\Plugin
+class PhpParallelLint extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     /**
      * @var string
      */
@@ -55,8 +45,8 @@ class PhpParallelLint implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci        = $phpci;
-        $this->build        = $build;
+        parent::__construct($phpci, $build);
+
         $this->directory    = $phpci->buildPath;
         $this->ignore       = $this->phpci->ignore;
 

--- a/PHPCI/Plugin/PhpSpec.php
+++ b/PHPCI/Plugin/PhpSpec.php
@@ -17,7 +17,7 @@ use PHPCI;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpSpec extends AbstractPlugin
+class PhpSpec extends AbstractExecutingPlugin
 {
     /**
      * @var array
@@ -42,10 +42,10 @@ class PhpSpec extends AbstractPlugin
         $curdir = getcwd();
         chdir($this->buildPath);
 
-        $phpspec = $this->phpci->findBinary(array('phpspec', 'phpspec.php'));
+        $phpspec = $this->executor->findBinary(array('phpspec', 'phpspec.php'));
 
-        $success = $this->phpci->executeCommand($phpspec . ' --format=junit --no-code-generation run');
-        $output = $this->phpci->getLastOutput();
+        $success = $this->executor->executeCommand($phpspec . ' --format=junit --no-code-generation run');
+        $output = $this->executor->getLastOutput();
 
         chdir($curdir);
 

--- a/PHPCI/Plugin/PhpSpec.php
+++ b/PHPCI/Plugin/PhpSpec.php
@@ -40,7 +40,7 @@ class PhpSpec extends AbstractPlugin
     public function execute()
     {
         $curdir = getcwd();
-        chdir($this->phpci->buildPath);
+        chdir($this->buildPath);
 
         $phpspec = $this->phpci->findBinary(array('phpspec', 'phpspec.php'));
 

--- a/PHPCI/Plugin/PhpSpec.php
+++ b/PHPCI/Plugin/PhpSpec.php
@@ -19,18 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpSpec implements PHPCI\Plugin
+class PhpSpec extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     /**
      * @var array
      */
@@ -44,8 +34,8 @@ class PhpSpec implements PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->options = $options;
     }
 

--- a/PHPCI/Plugin/PhpSpec.php
+++ b/PHPCI/Plugin/PhpSpec.php
@@ -10,8 +10,6 @@
 namespace PHPCI\Plugin;
 
 use PHPCI;
-use PHPCI\Builder;
-use PHPCI\Model\Build;
 
 /**
 * PHP Spec Plugin - Allows PHP Spec testing.
@@ -27,15 +25,12 @@ class PhpSpec extends AbstractPlugin
     protected $options;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->options = $options;
     }
 

--- a/PHPCI/Plugin/PhpTalLint.php
+++ b/PHPCI/Plugin/PhpTalLint.php
@@ -66,15 +66,6 @@ class PhpTalLint extends AbstractPlugin
             $this->suffixes = (array)$options['suffixes'];
         }
 
-        $this->setOptions($options);
-    }
-
-    /**
-     * Handle this plugin's options.
-     * @param $options
-     */
-    protected function setOptions($options)
-    {
         foreach (array('directories', 'tales', 'allowed_warnings', 'allowed_errors') as $key) {
             if (array_key_exists($key, $options)) {
                 $this->{$key} = $options[$key];

--- a/PHPCI/Plugin/PhpTalLint.php
+++ b/PHPCI/Plugin/PhpTalLint.php
@@ -22,7 +22,6 @@ class PhpTalLint extends AbstractExecutingPlugin
     protected $directories;
     protected $recursive = true;
     protected $suffixes;
-    protected $ignore;
 
     /**
      * @var string The path to a file contain custom phptal_tales_ functions
@@ -53,7 +52,6 @@ class PhpTalLint extends AbstractExecutingPlugin
     {
         $this->directories = array('');
         $this->suffixes = array('zpt');
-        $this->ignore = $this->phpci->ignore;
 
         $this->allowed_warnings = 0;
         $this->allowed_errors = 0;

--- a/PHPCI/Plugin/PhpTalLint.php
+++ b/PHPCI/Plugin/PhpTalLint.php
@@ -53,7 +53,7 @@ class PhpTalLint extends AbstractExecutingPlugin
     {
         $this->directories = array('');
         $this->suffixes = array('zpt');
-        $this->ignore = $phpci->ignore;
+        $this->ignore = $this->phpci->ignore;
 
         $this->allowed_warnings = 0;
         $this->allowed_errors = 0;

--- a/PHPCI/Plugin/PhpTalLint.php
+++ b/PHPCI/Plugin/PhpTalLint.php
@@ -154,7 +154,7 @@ class PhpTalLint extends AbstractPlugin
     protected function lintDirectory($path)
     {
         $success = true;
-        $directory = new \DirectoryIterator($this->phpci->buildPath . $path);
+        $directory = new \DirectoryIterator($this->buildPath . $path);
 
         foreach ($directory as $item) {
             if ($item->isDot()) {
@@ -189,7 +189,7 @@ class PhpTalLint extends AbstractPlugin
         $lint = dirname(__FILE__) . '/../../vendor/phptal/phptal/tools/phptal_lint.php';
         $cmd = '/usr/bin/env php ' . $lint . ' %s %s "%s"';
 
-        $this->phpci->executeCommand($cmd, $suffixes, $tales, $this->phpci->buildPath . $path);
+        $this->phpci->executeCommand($cmd, $suffixes, $tales, $this->buildPath . $path);
 
         $output = $this->phpci->getLastOutput();
 
@@ -234,7 +234,7 @@ class PhpTalLint extends AbstractPlugin
     {
         $tales = '';
         if (!empty($this->tales)) {
-            $tales = ' -i ' . $this->phpci->buildPath . $this->tales;
+            $tales = ' -i ' . $this->buildPath . $this->tales;
         }
 
         $suffixes = '';

--- a/PHPCI/Plugin/PhpTalLint.php
+++ b/PHPCI/Plugin/PhpTalLint.php
@@ -17,7 +17,7 @@ use PHPCI;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class PhpTalLint extends AbstractPlugin
+class PhpTalLint extends AbstractExecutingPlugin
 {
     protected $directories;
     protected $recursive = true;
@@ -78,15 +78,13 @@ class PhpTalLint extends AbstractPlugin
      */
     public function execute()
     {
-        $this->phpci->quiet = true;
-        $this->phpci->logExecOutput(false);
+        $this->executor->setQuiet(true);
 
         foreach ($this->directories as $dir) {
             $this->lintDirectory($dir);
         }
 
-        $this->phpci->quiet = false;
-        $this->phpci->logExecOutput(true);
+        $this->executor->setQuiet(false);
 
         $errors = 0;
         $warnings = 0;
@@ -180,9 +178,9 @@ class PhpTalLint extends AbstractPlugin
         $lint = dirname(__FILE__) . '/../../vendor/phptal/phptal/tools/phptal_lint.php';
         $cmd = '/usr/bin/env php ' . $lint . ' %s %s "%s"';
 
-        $this->phpci->executeCommand($cmd, $suffixes, $tales, $this->buildPath . $path);
+        $this->executor->executeCommand($cmd, $suffixes, $tales, $this->buildPath . $path);
 
-        $output = $this->phpci->getLastOutput();
+        $output = $this->executor->getLastOutput();
 
         if (preg_match('/Found (.+?) (error|warning)/i', $output, $matches)) {
             $rows = explode(PHP_EOL, $output);

--- a/PHPCI/Plugin/PhpTalLint.php
+++ b/PHPCI/Plugin/PhpTalLint.php
@@ -19,22 +19,12 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class PhpTalLint implements PHPCI\Plugin
+class PhpTalLint extends AbstractPlugin
 {
     protected $directories;
     protected $recursive = true;
     protected $suffixes;
     protected $ignore;
-
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
 
     /**
      * @var string The path to a file contain custom phptal_tales_ functions
@@ -65,8 +55,8 @@ class PhpTalLint implements PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->directories = array('');
         $this->suffixes = array('zpt');
         $this->ignore = $phpci->ignore;
@@ -222,7 +212,7 @@ class PhpTalLint implements PHPCI\Plugin
 
                 $row = str_replace('(use -i to include your custom modifier functions)', '', $row);
                 $message = str_replace($name . ': ', '', $row);
-                
+
                 $parts = explode(' (line ', $message);
 
                 $message = trim($parts[0]);

--- a/PHPCI/Plugin/PhpTalLint.php
+++ b/PHPCI/Plugin/PhpTalLint.php
@@ -10,8 +10,6 @@
 namespace PHPCI\Plugin;
 
 use PHPCI;
-use PHPCI\Builder;
-use PHPCI\Model\Build;
 
 /**
  * PHPTAL Lint Plugin - Provides access to PHPTAL lint functionality.
@@ -47,16 +45,12 @@ class PhpTalLint extends AbstractPlugin
     protected $failedPaths = array();
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->directories = array('');
         $this->suffixes = array('zpt');
         $this->ignore = $phpci->ignore;

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -97,7 +97,7 @@ class PhpUnit extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     protected function setOptions(array $options)
     {
         if (empty($options['config']) && empty($options['directory'])) {
-            $this->xmlConfigFile = self::findConfigFile($phpci->buildPath);
+            $this->xmlConfigFile = self::findConfigFile($this->buildPath);
         }
 
         if (isset($options['directory'])) {
@@ -182,13 +182,13 @@ class PhpUnit extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         } else {
             if ($this->runFrom) {
                 $curdir = getcwd();
-                chdir($this->phpci->buildPath.'/'.$this->runFrom);
+                chdir($this->buildPath.'/'.$this->runFrom);
             }
 
             $phpunit = $this->phpci->findBinary('phpunit');
 
             $cmd = $phpunit . ' --tap %s -c "%s" ' . $this->coverage . $this->path;
-            $success = $this->phpci->executeCommand($cmd, $this->args, $this->phpci->buildPath . $configPath);
+            $success = $this->phpci->executeCommand($cmd, $this->args, $this->buildPath . $configPath);
 
             if ($this->runFrom) {
                 chdir($curdir);
@@ -209,12 +209,12 @@ class PhpUnit extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             return $this->recurseArg($directory, array($this, "runDir"));
         } else {
             $curdir = getcwd();
-            chdir($this->phpci->buildPath);
+            chdir($this->buildPath);
 
             $phpunit = $this->phpci->findBinary('phpunit');
 
             $cmd = $phpunit . ' --tap %s "%s"';
-            $success = $this->phpci->executeCommand($cmd, $this->args, $this->phpci->buildPath . $directory);
+            $success = $this->phpci->executeCommand($cmd, $this->args, $this->buildPath . $directory);
             chdir($curdir);
             return $success;
         }

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -20,11 +20,9 @@ use PHPCI\Plugin\Util\TapParser;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
+class PhpUnit extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 {
     protected $args;
-    protected $phpci;
-    protected $build;
 
     /**
      * @var string|string[] $directory The directory (or array of dirs) to run PHPUnit on
@@ -105,8 +103,7 @@ class PhpUnit implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         if (empty($options['config']) && empty($options['directory'])) {
             $this->xmlConfigFile = self::findConfigFile($phpci->buildPath);

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -90,21 +90,12 @@ class PhpUnit extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     }
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         if (empty($options['config']) && empty($options['directory'])) {
             $this->xmlConfigFile = self::findConfigFile($phpci->buildPath);
         }

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -132,8 +132,7 @@ class PhpUnit extends AbstractInterpolatingPlugin implements PHPCI\ZeroConfigPlu
     public function execute()
     {
         if (empty($this->xmlConfigFile) && empty($this->directory)) {
-            $this->phpci->logFailure('Neither configuration file nor test directory found.');
-            return false;
+            throw new \Exception('Neither configuration file nor test directory found.');
         }
 
         $success = true;

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -138,7 +138,7 @@ class PhpUnit extends AbstractInterpolatingPlugin implements PHPCI\ZeroConfigPlu
 
         $success = true;
 
-        $this->phpci->logExecOutput(false);
+        $this->executor->setQuiet(true);
 
         // Run any config files first. This can be either a single value or an array.
         if ($this->xmlConfigFile !== null) {
@@ -150,7 +150,7 @@ class PhpUnit extends AbstractInterpolatingPlugin implements PHPCI\ZeroConfigPlu
             $success &= $this->runDir($this->directory);
         }
 
-        $tapString = $this->phpci->getLastOutput();
+        $tapString = $this->executor->getLastOutput();
         $tapString = mb_convert_encoding($tapString, "UTF-8", "ISO-8859-1");
 
         try {
@@ -166,7 +166,7 @@ class PhpUnit extends AbstractInterpolatingPlugin implements PHPCI\ZeroConfigPlu
         $this->build->storeMeta('phpunit-errors', $failures);
         $this->build->storeMeta('phpunit-data', $output);
 
-        $this->phpci->logExecOutput(true);
+        $this->executor->setQuiet(false);
 
         return $success;
     }
@@ -186,10 +186,10 @@ class PhpUnit extends AbstractInterpolatingPlugin implements PHPCI\ZeroConfigPlu
                 chdir($this->buildPath.'/'.$this->runFrom);
             }
 
-            $phpunit = $this->phpci->findBinary('phpunit');
+            $phpunit = $this->executor->findBinary('phpunit');
 
             $cmd = $phpunit . ' --tap %s -c "%s" ' . $this->coverage . $this->path;
-            $success = $this->phpci->executeCommand($cmd, $this->args, $this->buildPath . $configPath);
+            $success = $this->executor->executeCommand($cmd, $this->args, $this->buildPath . $configPath);
 
             if ($this->runFrom) {
                 chdir($curdir);
@@ -212,10 +212,10 @@ class PhpUnit extends AbstractInterpolatingPlugin implements PHPCI\ZeroConfigPlu
             $curdir = getcwd();
             chdir($this->buildPath);
 
-            $phpunit = $this->phpci->findBinary('phpunit');
+            $phpunit = $this->executor->findBinary('phpunit');
 
             $cmd = $phpunit . ' --tap %s "%s"';
-            $success = $this->phpci->executeCommand($cmd, $this->args, $this->buildPath . $directory);
+            $success = $this->executor->executeCommand($cmd, $this->args, $this->buildPath . $directory);
             chdir($curdir);
             return $success;
         }

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -156,7 +156,6 @@ class PhpUnit extends AbstractInterpolatingPlugin implements PHPCI\ZeroConfigPlu
             $tapParser = new TapParser($tapString);
             $output = $tapParser->parse();
         } catch (\Exception $ex) {
-            $this->logger->logFailure($tapString);
             throw $ex;
         }
 

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -13,6 +13,7 @@ use PHPCI;
 use PHPCI\Builder;
 use PHPCI\Model\Build;
 use PHPCI\Plugin\Util\TapParser;
+use PHPCI\Helper\BuildInterpolator;
 
 /**
 * PHP Unit Plugin - Allows PHP Unit testing.
@@ -20,7 +21,7 @@ use PHPCI\Plugin\Util\TapParser;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class PhpUnit extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
+class PhpUnit extends AbstractInterpolatingPlugin implements PHPCI\ZeroConfigPlugin
 {
     protected $args;
 
@@ -113,7 +114,7 @@ class PhpUnit extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         }
 
         if (isset($options['args'])) {
-            $this->args = $this->phpci->interpolate($options['args']);
+            $this->args = $this->interpolator->interpolate($options['args']);
         }
 
         if (isset($options['path'])) {

--- a/PHPCI/Plugin/PhpUnit.php
+++ b/PHPCI/Plugin/PhpUnit.php
@@ -156,7 +156,7 @@ class PhpUnit extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $tapParser = new TapParser($tapString);
             $output = $tapParser->parse();
         } catch (\Exception $ex) {
-            $this->phpci->logFailure($tapString);
+            $this->logger->logFailure($tapString);
             throw $ex;
         }
 

--- a/PHPCI/Plugin/Shell.php
+++ b/PHPCI/Plugin/Shell.php
@@ -19,18 +19,8 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Shell implements \PHPCI\Plugin
+class Shell extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     protected $args;
 
     /**
@@ -52,8 +42,7 @@ class Shell implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         if (isset($options['command'])) {
             // Keeping this for backwards compatibility, new projects should use interpolation vars.

--- a/PHPCI/Plugin/Shell.php
+++ b/PHPCI/Plugin/Shell.php
@@ -35,7 +35,7 @@ class Shell extends AbstractPlugin
     {
         if (isset($options['command'])) {
             // Keeping this for backwards compatibility, new projects should use interpolation vars.
-            $options['command'] = str_replace("%buildpath%", $this->phpci->buildPath, $options['command']);
+            $options['command'] = str_replace("%buildpath%", $this->buildPath, $options['command']);
             $this->commands = array($options['command']);
             return;
         }

--- a/PHPCI/Plugin/Shell.php
+++ b/PHPCI/Plugin/Shell.php
@@ -17,7 +17,7 @@ use PHPCI\Helper\Lang;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class Shell extends AbstractPlugin
+class Shell extends AbstractInterpolatingPlugin
 {
     protected $args;
 
@@ -64,7 +64,7 @@ class Shell extends AbstractPlugin
         $success = true;
 
         foreach ($this->commands as $command) {
-            $command = $this->phpci->interpolate($command);
+            $command = $this->interpolator->interpolate($command);
 
             if (!$this->phpci->executeCommand($command)) {
                 $success = false;

--- a/PHPCI/Plugin/Shell.php
+++ b/PHPCI/Plugin/Shell.php
@@ -9,9 +9,7 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
 use PHPCI\Helper\Lang;
-use PHPCI\Model\Build;
 
 /**
  * Shell Plugin - Allows execute shell commands.
@@ -29,21 +27,12 @@ class Shell extends AbstractPlugin
     protected $commands = array();
 
     /**
-     * Standard Constructor
+     * Configure the plugin.
      *
-     * $options['directory'] Output Directory. Default: %BUILDPATH%
-     * $options['filename']  Phar Filename. Default: build.phar
-     * $options['regexp']    Regular Expression Filename Capture. Default: /\.php$/
-     * $options['stub']      Stub Content. No Default Value
-     *
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         if (isset($options['command'])) {
             // Keeping this for backwards compatibility, new projects should use interpolation vars.
             $options['command'] = str_replace("%buildpath%", $this->phpci->buildPath, $options['command']);

--- a/PHPCI/Plugin/Shell.php
+++ b/PHPCI/Plugin/Shell.php
@@ -66,7 +66,7 @@ class Shell extends AbstractInterpolatingPlugin
         foreach ($this->commands as $command) {
             $command = $this->interpolator->interpolate($command);
 
-            if (!$this->phpci->executeCommand($command)) {
+            if (!$this->executor->executeCommand($command)) {
                 $success = false;
             }
         }

--- a/PHPCI/Plugin/SlackNotify.php
+++ b/PHPCI/Plugin/SlackNotify.php
@@ -8,8 +8,6 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
-use PHPCI\Model\Build;
 
 /**
  * Slack Plugin
@@ -26,16 +24,12 @@ class SlackNotify extends AbstractPlugin
     private $icon;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
-     * @throws \Exception
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         if (is_array($options) && isset($options['webhook_url'])) {
             $this->webHook = trim($options['webhook_url']);
 

--- a/PHPCI/Plugin/SlackNotify.php
+++ b/PHPCI/Plugin/SlackNotify.php
@@ -17,7 +17,7 @@ use PHPCI\Model\Build;
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class SlackNotify implements \PHPCI\Plugin
+class SlackNotify extends AbstractPlugin
 {
     private $webHook;
     private $room;
@@ -34,8 +34,7 @@ class SlackNotify implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         if (is_array($options) && isset($options['webhook_url'])) {
             $this->webHook = trim($options['webhook_url']);

--- a/PHPCI/Plugin/SlackNotify.php
+++ b/PHPCI/Plugin/SlackNotify.php
@@ -8,14 +8,13 @@
 
 namespace PHPCI\Plugin;
 
-
 /**
  * Slack Plugin
  * @author       Stephen Ball <phpci@stephen.rebelinblue.com>
  * @package      PHPCI
  * @subpackage   Plugins
  */
-class SlackNotify extends AbstractPlugin
+class SlackNotify extends AbstractInterpolatingPlugin
 {
     private $webHook;
     private $room;
@@ -67,7 +66,7 @@ class SlackNotify extends AbstractPlugin
      */
     public function execute()
     {
-        $message = $this->phpci->interpolate($this->message);
+        $message = $this->interpolator->interpolate($this->message);
 
         $successfulBuild = $this->build->isSuccessful();
 

--- a/PHPCI/Plugin/Sqlite.php
+++ b/PHPCI/Plugin/Sqlite.php
@@ -53,16 +53,11 @@ class Sqlite extends AbstractPlugin
      */
     public function execute()
     {
-        try {
-            $opts = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
-            $pdo = new PDO('sqlite:' . $this->path, $opts);
+        $opts = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
+        $pdo = new PDO('sqlite:' . $this->path, $opts);
 
-            foreach ($this->queries as $query) {
-                $pdo->query($this->interpolator->interpolate($query));
-            }
-        } catch (\Exception $ex) {
-            $this->logger->logFailure($ex->getMessage());
-            return false;
+        foreach ($this->queries as $query) {
+            $pdo->query($this->interpolator->interpolate($query));
         }
         return true;
     }

--- a/PHPCI/Plugin/Sqlite.php
+++ b/PHPCI/Plugin/Sqlite.php
@@ -37,12 +37,14 @@ class Sqlite extends AbstractPlugin
     protected function setOptions(array $options)
     {
         $this->queries = $options;
-        $buildSettings = $this->phpci->getConfig('build_settings');
+    }
 
-        if (isset($buildSettings['sqlite'])) {
-            $sql = $buildSettings['sqlite'];
-            $this->path = $sql['path'];
-        }
+    /**
+     * {@inheritdoc}
+     */
+    protected function setCommonSettings(array $settings)
+    {
+        $this->path = $settings['path'];
     }
 
     /**

--- a/PHPCI/Plugin/Sqlite.php
+++ b/PHPCI/Plugin/Sqlite.php
@@ -59,7 +59,7 @@ class Sqlite extends AbstractPlugin
                 $pdo->query($this->phpci->interpolate($query));
             }
         } catch (\Exception $ex) {
-            $this->phpci->logFailure($ex->getMessage());
+            $this->logger->logFailure($ex->getMessage());
             return false;
         }
         return true;

--- a/PHPCI/Plugin/Sqlite.php
+++ b/PHPCI/Plugin/Sqlite.php
@@ -19,18 +19,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Sqlite implements \PHPCI\Plugin
+class Sqlite extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     /**
      * @var array
      */
@@ -48,8 +38,8 @@ class Sqlite implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci   = $phpci;
-        $this->build   = $build;
+        parent::__construct($phpci, $build);
+
         $this->queries = $options;
         $buildSettings = $phpci->getConfig('build_settings');
 

--- a/PHPCI/Plugin/Sqlite.php
+++ b/PHPCI/Plugin/Sqlite.php
@@ -10,8 +10,6 @@
 namespace PHPCI\Plugin;
 
 use PDO;
-use PHPCI\Builder;
-use PHPCI\Model\Build;
 
 /**
 * SQLite Plugin — Provides access to a SQLite database.
@@ -32,16 +30,14 @@ class Sqlite extends AbstractPlugin
     protected $path;
 
     /**
-     * @param Builder $phpci
-     * @param Build   $build
-     * @param array   $options
+     * Configure the plugin.
+     *
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->queries = $options;
-        $buildSettings = $phpci->getConfig('build_settings');
+        $buildSettings = $this->phpci->getConfig('build_settings');
 
         if (isset($buildSettings['sqlite'])) {
             $sql = $buildSettings['sqlite'];

--- a/PHPCI/Plugin/Sqlite.php
+++ b/PHPCI/Plugin/Sqlite.php
@@ -56,7 +56,7 @@ class Sqlite extends AbstractPlugin
             $pdo = new PDO('sqlite:' . $this->path, $opts);
 
             foreach ($this->queries as $query) {
-                $pdo->query($this->phpci->interpolate($query));
+                $pdo->query($this->interpolator->interpolate($query));
             }
         } catch (\Exception $ex) {
             $this->logger->logFailure($ex->getMessage());

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -20,13 +20,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
+class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
     /**
      * @var array
      */
@@ -88,8 +83,8 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
+
         $this->suffixes = array('php');
         $this->directory = $phpci->buildPath;
         $this->path = '';

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -111,7 +111,7 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 
         list($errorCount, $data) = $this->getErrorList();
 
-        $this->logger->log("Found $errorCount instances of " . implode(', ', $this->searches));
+        $this->logger->notice("Found $errorCount instances of " . implode(', ', $this->searches));
 
         $this->build->storeMeta('technical_debt-warnings', $errorCount);
         $this->build->storeMeta('technical_debt-data', $data);

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -49,11 +49,6 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     protected $path;
 
     /**
-     * @var array - paths to ignore
-     */
-    protected $ignore;
-
-    /**
      * @var array - terms to search for
      */
     protected $searches;
@@ -86,7 +81,6 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         $this->suffixes = array('php');
         $this->directory = $this->buildPath;
         $this->path = '';
-        $this->ignore = $this->phpci->ignore;
         $this->allowed_warnings = 0;
         $this->allowed_errors = 0;
         $this->searches = array('TODO', 'FIXME', 'TO DO', 'FIX ME');

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -113,7 +113,7 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     public function execute()
     {
         $success = true;
-        $this->phpci->logExecOutput(false);
+        $this->executor->setQuiet(true);
 
         list($errorCount, $data) = $this->getErrorList();
 
@@ -125,6 +125,8 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
         if ($this->allowed_errors != -1 && $errorCount > $this->allowed_errors) {
             $success = false;
         }
+
+        $this->executor->setQuiet(false);
 
         return $success;
     }

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -117,7 +117,7 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
 
         list($errorCount, $data) = $this->getErrorList();
 
-        $this->phpci->log("Found $errorCount instances of " . implode(', ', $this->searches));
+        $this->logger->log("Found $errorCount instances of " . implode(', ', $this->searches));
 
         $this->build->storeMeta('technical_debt-warnings', $errorCount);
         $this->build->storeMeta('technical_debt-data', $data);
@@ -179,7 +179,7 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
                     $content = trim($allLines[$lineNumber - 1]);
 
                     $errorCount++;
-                    $this->phpci->log("Found $search on line $lineNumber of $file:\n$content");
+                    $this->logger->log("Found $search on line $lineNumber of $file:\n$content");
 
                     $fileName = str_replace($this->directory, '', $file);
                     $data[] = array(

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -77,16 +77,14 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     }
 
     /**
-     * @param \PHPCI\Builder     $phpci
-     * @param \PHPCI\Model\Build $build
-     * @param array              $options
+     * Configure the plugin.
+     *
+     * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->suffixes = array('php');
-        $this->directory = $phpci->buildPath;
+        $this->directory = $this->phpci->buildPath;
         $this->path = '';
         $this->ignore = $this->phpci->ignore;
         $this->allowed_warnings = 0;
@@ -101,14 +99,7 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
             $this->allowed_warnings = -1;
             $this->allowed_errors = -1;
         }
-    }
 
-    /**
-     * Handle this plugin's options.
-     * @param $options
-     */
-    protected function setOptions($options)
-    {
         foreach (array('directory', 'path', 'ignore', 'allowed_warnings', 'allowed_errors') as $key) {
             if (array_key_exists($key, $options)) {
                 $this->{$key} = $options[$key];

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -84,7 +84,7 @@ class TechnicalDebt extends AbstractPlugin implements PHPCI\ZeroConfigPlugin
     protected function setOptions(array $options)
     {
         $this->suffixes = array('php');
-        $this->directory = $this->phpci->buildPath;
+        $this->directory = $this->buildPath;
         $this->path = '';
         $this->ignore = $this->phpci->ignore;
         $this->allowed_warnings = 0;

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -203,7 +203,6 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
                     );
 
                     $this->build->reportError($this->phpci, $fileName, $lineNumber, $content);
-
                 }
             }
         }

--- a/PHPCI/Plugin/Util/Factory.php
+++ b/PHPCI/Plugin/Util/Factory.php
@@ -2,6 +2,7 @@
 
 namespace PHPCI\Plugin\Util;
 
+use Psr\Log\LoggerAwareInterface;
 /**
  * Plugin Factory - Loads Plugins and passes required dependencies.
  * @package PHPCI\Plugin\Util
@@ -102,6 +103,14 @@ class Factory
             $plugin = $reflectedPlugin->newInstanceArgs($argsToUse);
         } else {
             $plugin = $reflectedPlugin->newInstance();
+        }
+
+        if ($plugin instanceof InterpolatorAwareInterface) {
+            $plugin->setInterpolator($this->getResourceFor('PHPCI\Helper\BuildInterpolator'));
+        }
+
+        if ($plugin instanceof LoggerAwareInterface) {
+            $plugin->setLogger($this->getResourceFor('Psr\Log\LoggerInterface'));
         }
 
         return $plugin;

--- a/PHPCI/Plugin/Util/InterpolatorAwareInterface.php
+++ b/PHPCI/Plugin/Util/InterpolatorAwareInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * PHPCI - Continuous Integration for PHP
+ *
+ * @copyright    Copyright 2014, Block 8 Limited.
+ * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ * @link         https://www.phptesting.org/
+ */
+
+namespace PHPCI\Plugin\Util;
+
+use PHPCI\Helper\BuildInterpolator;
+
+/**
+ * An object that accepts a build interpolator.
+ *
+ * @author   Adirelle <adirelle@gmail.com>
+ */
+interface InterpolatorAwareInterface
+{
+    /**
+     * Sets the BuildInterpolator.
+     *
+     * @param BuildInterpolator $interpolator
+     */
+    public function setInterpolator(BuildInterpolator $interpolator);
+}

--- a/PHPCI/Plugin/Util/TapParser.php
+++ b/PHPCI/Plugin/Util/TapParser.php
@@ -131,10 +131,8 @@ class TapParser
     {
         if (preg_match(self::TEST_COUNTS_PATTERN, $line, $matches)) {
             $this->testCount = intval($matches[1]);
-
         } elseif (preg_match(self::TEST_DIAGNOSTIC, $line)) {
             return;
-
         } elseif (preg_match(self::TEST_LINE_PATTERN, $line, $matches)) {
             $this->results[] = $this->processTestLine(
                 $matches[1],
@@ -142,7 +140,6 @@ class TapParser
                 isset($matches[3]) ? $matches[3] : null,
                 isset($matches[4]) ? $matches[4] : null
             );
-
         } elseif (preg_match(self::TEST_YAML_START, $line, $matches)) {
             $diagnostic = $this->processYamlBlock($matches[1]);
             $test = array_pop($this->results);
@@ -151,7 +148,6 @@ class TapParser
                 unset($diagnostic['message']);
             }
             $this->results[] = array_replace($test, $diagnostic);
-
         } else {
             throw new Exception(sprintf('Incorrect TAP data, line %d: %s', $this->lineNumber, $line));
         }
@@ -207,7 +203,6 @@ class TapParser
                 break;
             }
             $yamlLines[] = substr($line, strlen($indent));
-
         } while (true);
 
         return Yaml::parse(join("\n", $yamlLines));

--- a/PHPCI/Plugin/Wipe.php
+++ b/PHPCI/Plugin/Wipe.php
@@ -18,18 +18,8 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Wipe implements \PHPCI\Plugin
+class Wipe extends AbstractPlugin
 {
-    /**
-     * @var \PHPCI\Builder
-     */
-    protected $phpci;
-
-    /**
-     * @var \PHPCI\Model\Build
-     */
-    protected $build;
-
     protected $directory;
 
     /**
@@ -40,9 +30,9 @@ class Wipe implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
+        parent::__construct($phpci, $build);
+
         $path               = $phpci->buildPath;
-        $this->phpci        = $phpci;
-        $this->build = $build;
         $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
     }
 

--- a/PHPCI/Plugin/Wipe.php
+++ b/PHPCI/Plugin/Wipe.php
@@ -9,9 +9,6 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
-use PHPCI\Model\Build;
-
 /**
 * Wipe Plugin - Wipes a folder
 * @author       Claus Due <claus@namelesscoder.net>
@@ -23,17 +20,13 @@ class Wipe extends AbstractPlugin
     protected $directory;
 
     /**
-     * Set up the plugin, configure options, etc.
-     * @param Builder $phpci
-     * @param Build $build
+     * Configure the plugin.
+     *
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
-        $path               = $phpci->buildPath;
-        $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
+        $this->directory = isset($options['directory']) ? $options['directory'] : $this->phpci->buildPath;
     }
 
     /**

--- a/PHPCI/Plugin/Wipe.php
+++ b/PHPCI/Plugin/Wipe.php
@@ -26,7 +26,7 @@ class Wipe extends AbstractPlugin
      */
     protected function setOptions(array $options)
     {
-        $this->directory = isset($options['directory']) ? $options['directory'] : $this->phpci->buildPath;
+        $this->directory = isset($options['directory']) ? $options['directory'] : $this->buildPath;
     }
 
     /**
@@ -34,7 +34,7 @@ class Wipe extends AbstractPlugin
     */
     public function execute()
     {
-        $build = $this->phpci->buildPath;
+        $build = $this->buildPath;
 
         if ($this->directory == $build || empty($this->directory)) {
             return true;

--- a/PHPCI/Plugin/Wipe.php
+++ b/PHPCI/Plugin/Wipe.php
@@ -15,7 +15,7 @@ namespace PHPCI\Plugin;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Wipe extends AbstractPlugin
+class Wipe extends AbstractExecutingPlugin
 {
     protected $directory;
 

--- a/PHPCI/Plugin/Xmpp.php
+++ b/PHPCI/Plugin/Xmpp.php
@@ -18,7 +18,7 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class XMPP implements \PHPCI\Plugin
+class Xmpp implements \PHPCI\Plugin
 {
     protected $directory;
     protected $phpci;

--- a/PHPCI/Plugin/Xmpp.php
+++ b/PHPCI/Plugin/Xmpp.php
@@ -18,11 +18,9 @@ use PHPCI\Model\Build;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Xmpp implements \PHPCI\Plugin
+class Xmpp extends AbstractPlugin
 {
     protected $directory;
-    protected $phpci;
-    protected $build;
 
     /**
      * @var string, username of sender account xmpp
@@ -67,8 +65,7 @@ class Xmpp implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $this->phpci = $phpci;
-        $this->build = $build;
+        parent::__construct($phpci, $build);
 
         $this->username    = '';
         $this->password    = '';

--- a/PHPCI/Plugin/Xmpp.php
+++ b/PHPCI/Plugin/Xmpp.php
@@ -15,7 +15,7 @@ namespace PHPCI\Plugin;
 * @package      PHPCI
 * @subpackage   Plugins
 */
-class Xmpp extends AbstractPlugin
+class Xmpp extends AbstractExecutingPlugin
 {
     protected $directory;
 
@@ -129,7 +129,7 @@ class Xmpp extends AbstractPlugin
     */
     public function execute()
     {
-        $sendxmpp = $this->phpci->findBinary('sendxmpp');
+        $sendxmpp = $this->executor->findBinary('sendxmpp');
 
         /*
          * Without recipients we can't send notification
@@ -166,14 +166,14 @@ class Xmpp extends AbstractPlugin
         $cmd = $sendxmpp . "%s -f %s -m %s %s";
         $recipients = implode(' ', $this->recipients);
 
-        $success = $this->phpci->executeCommand($cmd, $tls, $config_file, $message_file, $recipients);
+        $success = $this->executor->executeCommand($cmd, $tls, $config_file, $message_file, $recipients);
 
-        print $this->phpci->getLastOutput();
+        print $this->executor->getLastOutput();
 
         /*
          * Remove temp message file
          */
-        $this->phpci->executeCommand("rm -rf ".$message_file);
+        $this->executor->executeCommand("rm -rf ".$message_file);
 
         return $success;
     }

--- a/PHPCI/Plugin/Xmpp.php
+++ b/PHPCI/Plugin/Xmpp.php
@@ -113,8 +113,8 @@ class Xmpp extends AbstractPlugin
      */
     public function findConfigFile()
     {
-        if (file_exists($this->phpci->buildPath . '/.sendxmpprc')) {
-            if (md5(file_get_contents($this->phpci->buildPath . '/.sendxmpprc')) !== md5($this->getConfigFormat())) {
+        if (file_exists($this->buildPath . '/.sendxmpprc')) {
+            if (md5(file_get_contents($this->buildPath . '/.sendxmpprc')) !== md5($this->getConfigFormat())) {
                 return null;
             }
 
@@ -141,7 +141,7 @@ class Xmpp extends AbstractPlugin
         /*
          * Try to build conf file
          */
-        $config_file = $this->phpci->buildPath . '/.sendxmpprc';
+        $config_file = $this->buildPath . '/.sendxmpprc';
         if (is_null($this->findConfigFile())) {
             file_put_contents($config_file, $this->getConfigFormat());
             chmod($config_file, 0600);
@@ -155,7 +155,7 @@ class Xmpp extends AbstractPlugin
             $tls = ' -t';
         }
 
-        $message_file = $this->phpci->buildPath . '/' . uniqid('xmppmessage');
+        $message_file = $this->buildPath . '/' . uniqid('xmppmessage');
         if ($this->buildMessage($message_file) === false) {
             return false;
         }

--- a/PHPCI/Plugin/Xmpp.php
+++ b/PHPCI/Plugin/Xmpp.php
@@ -9,9 +9,6 @@
 
 namespace PHPCI\Plugin;
 
-use PHPCI\Builder;
-use PHPCI\Model\Build;
-
 /**
 * XMPP Notification - Send notification for successful or failure build
 * @author       Alexandre Russo <dev.github@ange7.com>
@@ -58,15 +55,12 @@ class Xmpp extends AbstractPlugin
     protected $date_format;
 
     /**
+     * Configure the plugin.
      *
-     * @param Builder $phpci
-     * @param Build $build
      * @param array $options
      */
-    public function __construct(Builder $phpci, Build $build, array $options = array())
+    protected function setOptions(array $options)
     {
-        parent::__construct($phpci, $build);
-
         $this->username    = '';
         $this->password    = '';
         $this->server      = '';
@@ -86,16 +80,6 @@ class Xmpp extends AbstractPlugin
             }
         }
 
-        $this->setOptions($options);
-    }
-
-    /**
-     * Set options configuration for plugin
-     *
-     * @param array $options
-     */
-    protected function setOptions($options)
-    {
         foreach (array('username', 'password', 'alias', 'tls', 'server', 'date_format') as $key) {
             if (array_key_exists($key, $options)) {
                 $this->{$key} = $options[$key];


### PR DESCRIPTION
**Contribution Type:** refactor
**Primary Area:** plugins
**Link to Intent to Implement:** #899 

**Description of changes:**

* Reducing duplicated code in plugins.
* Removing the dependency to Builder from plugins.

This should open the way to several other improvements, e.g.:
* Create a per-plugin CommandExecutor (plugin isolation),
* Provide a common way to deal with options (default, validation, maybe description),
* Pure PSR logging, i.e. getting rid of the BuildLogger.

**Description of solution:**
- [x] Create several abstract classes to host common code.
- [x] Add services to the container of the plugin factory: BuildInterpolator, CommandExecutor, BuildLogger.
- [x] List required services in plugin constructors, so they get injected by the plugin factory: BuildInterpolator, CommandExecutor, BuildLogger.
- [x] Pass the "ignore" build setting to the plugins that use it.
- [x] Pass the plugin-specific build settings to the plugins that require them.
- ~~Handle the common option "directory".~~ Edit: the option does not have the same sense for all plugins.
- ~~Handle the common option "executable".~~ Edit: this option does not have the same name for all plugins.
- ~~Create an AbstractPdoPlugin as ancestor of plugins dealing with PDO (sqlite3, mysql, pgsql).~~ Edit: postponed to another PR.
- ~~Create an AbstractNodeJsPlugin as ancestor of plugins using node.js (grunt, gulp).~~ Edit: Actually need to be split in a NPM and two Gulp/Grunt plugins, postponed to another PR.
- [ ] Test the abstract classes.
- [ ] Document the abstract classes.
- [ ] Write a wiki page about writing plugins.