### PR TITLE
Change gitlab file link in plugins

### DIFF
--- a/PHPCI/Model/Build/GitlabBuild.php
+++ b/PHPCI/Model/Build/GitlabBuild.php
@@ -47,8 +47,7 @@ class GitlabBuild extends RemoteGitBuild
             'http://%s/%s/blob/%s/{FILE}#L{LINE}',
             $this->getProject()->getAccessInformation("domain"),
             $this->getProject()->getReference(),
-            $this->getgetCommitId()
-            //$this->getBranch()
+            $this->getCommitId()
         );
     }
 

--- a/PHPCI/Model/Build/GitlabBuild.php
+++ b/PHPCI/Model/Build/GitlabBuild.php
@@ -47,7 +47,8 @@ class GitlabBuild extends RemoteGitBuild
             'http://%s/%s/blob/%s/{FILE}#L{LINE}',
             $this->getProject()->getAccessInformation("domain"),
             $this->getProject()->getReference(),
-            $this->getBranch()
+            $this->getgetCommitId()
+            //$this->getBranch()
         );
     }
 


### PR DESCRIPTION
Running builds leave a file link with an error like "http://gitlab.example.com/root/project/blob/master/index.php#L6" but it is pointing to the actual file, not the file with a bug, example "http://gitlab.example.com/root/project/blob/97f0a6453d5913f4b55d660fbf2d629240ca7237/index.php#L6"