### PR TITLE
Allow overriding the build directory in local_vars.php

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -287,7 +287,7 @@ class Builder implements LoggerAwareInterface
      */
     protected function setupBuild()
     {
-        $this->buildPath = PHPCI_DIR . 'PHPCI/build/' . $this->build->getId() . '/';
+        $this->buildPath = PHPCI_BUILD_DIR . 'PHPCI/build/' . $this->build->getId() . '/';
         $this->build->currentBuildPath = $this->buildPath;
 
         $this->interpolator->setupInterpolationVars(

--- a/PHPCI/Command/RunCommand.php
+++ b/PHPCI/Command/RunCommand.php
@@ -178,7 +178,7 @@ class RunCommand extends Command
 
     protected function removeBuildDirectory($build)
     {
-        $buildPath = PHPCI_DIR . 'PHPCI/build/' . $build->getId() . '/';
+        $buildPath = PHPCI_BUILD_DIR . 'PHPCI/build/' . $build->getId() . '/';
 
         if (is_dir($buildPath)) {
             $cmd = 'rm -Rf "%s"';

--- a/vars.php
+++ b/vars.php
@@ -6,6 +6,10 @@ if (!defined('APPLICATION_PATH')) {
     define('PHPCI_DIR', APPLICATION_PATH);
 }
 
+if (!defined('PHPCI_BUILD_DIR')) {
+    define('PHPCI_BUILD_DIR', PHPCI_DIR);
+}
+
 // Define our PHPCI_URL, if not already defined:
 if (!defined('PHPCI_URL') && isset($config)) {
     define('PHPCI_URL', $config->get('phpci.url', '') . '/');


### PR DESCRIPTION
Hi guys

This is a very simple PR to allow moving the build directory to a custom location using a define in vars.php/local_vars.php. My use case is that I want to be able to store the build on a much faster disk.

I haven't provided any unit tests for this PR. Let me know if I need to. Similarly if there's documentation that I should update somewhere.

Thanks

Ronan