### PR TITLE
The manual build button creates build for the currently watched branch.

### DIFF
--- a/PHPCI/View/Project/view.phtml
+++ b/PHPCI/View/Project/view.phtml
@@ -6,7 +6,7 @@
 
 <div class="clearfix"  style="margin-bottom: 20px;">
     <div class="pull-right btn-group">
-        <a class="btn btn-success" href="<?php print PHPCI_URL . 'project/build/' . $project->getId(); ?>">
+        <a class="btn btn-success" href="<?php print PHPCI_URL . 'project/build/' . $project->getId(); ?>/<?php echo urlencode($branch) ?>">
             <?php Lang::out('build_now'); ?>
         </a>
 


### PR DESCRIPTION
Contribution Type: new feature
Primary Area: front-end
Link to Bug: #926 

Description of change: clicking on the "Build now" button on the project view now uses the currently watched branch.

Description of solution: pass the branch in the project/build route; the action was already expected it.