### PR TITLE
Commit Id on Manual Build 

### DIFF
--- a/PHPCI/Model/Build/RemoteGitBuild.php
+++ b/PHPCI/Model/Build/RemoteGitBuild.php
@@ -124,16 +124,16 @@ class RemoteGitBuild extends Build
         $success = true;
         $commit = $this->getCommitId();
 
+        $chdir = IS_WIN ? 'cd /d "%s"' : 'cd "%s"';
+
         if (!empty($commit) && $commit != 'Manual') {
-            $cmd = 'cd "%s"';
+            $cmd = $chdir . ' && git checkout %s --quiet';
+            $success = $builder->executeCommand($cmd, $cloneTo, $commit);
+        }
 
-            if (IS_WIN) {
-                $cmd = 'cd /d "%s"';
-            }
-
-            $cmd .= ' && git checkout %s --quiet';
-
-            $success = $builder->executeCommand($cmd, $cloneTo, $this->getCommitId());
+        // Always update the commit hash with the actual HEAD hash
+        if ($builder->executeCommand($chdir . ' && git rev-parse HEAD', $cloneTo)) {
+            $this->setCommitId(trim($builder->getLastOutput()));
         }
 
         return $success;

--- a/PHPCI/Service/BuildService.php
+++ b/PHPCI/Service/BuildService.php
@@ -59,6 +59,7 @@ class BuildService
             $build->setCommitId($commitId);
         } else {
             $build->setCommitId('Manual');
+            $build->setCommitMessage(Lang::get('manual_build'));
         }
 
         if (!is_null($branch)) {

--- a/PHPCI/Service/BuildService.php
+++ b/PHPCI/Service/BuildService.php
@@ -9,6 +9,7 @@
 
 namespace PHPCI\Service;
 
+use PHPCI\Helper\Lang;
 use PHPCI\Model\Build;
 use PHPCI\Model\Project;
 use PHPCI\Store\BuildStore;

--- a/Tests/PHPCI/Service/BuildServiceTest.php
+++ b/Tests/PHPCI/Service/BuildServiceTest.php
@@ -56,7 +56,7 @@ class BuildServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($returnValue->getStarted());
         $this->assertNull($returnValue->getFinished());
         $this->assertNull($returnValue->getLog());
-        $this->assertEmpty($returnValue->getCommitMessage());
+        $this->assertEquals(\PHPCI\Helper\Lang::get('manual_build'), $returnValue->getCommitMessage());
         $this->assertNull($returnValue->getCommitterEmail());
         $this->assertNull($returnValue->getExtra());
         $this->assertEquals('master', $returnValue->getBranch());


### PR DESCRIPTION
Contribution Type: new feature
Primary Area: builder
Link to Bug: #924 

Description of change:
*  Show the actual commit hash for manual builds.

Description of solution: 
* In BuildService, sets localized "Manual build" as the build comment for manual builds.
* In RemoteGitBuild::postCloneSetup, update the commit id with the actual hash (using `get rev-parse HEAD`). 

