### PR TITLE
PHPCI\Helper\Diff::getLinePositions might return null

### DIFF
--- a/PHPCI/Helper/Diff.php
+++ b/PHPCI/Helper/Diff.php
@@ -22,7 +22,7 @@ class Diff
     /**
      * Take a diff
      * @param string $diff
-     * @return array
+     * @return array|null
      */
     public function getLinePositions($diff)
     {

--- a/PHPCI/Model/Build/GithubBuild.php
+++ b/PHPCI/Model/Build/GithubBuild.php
@@ -221,6 +221,10 @@ class GithubBuild extends RemoteGitBuild
         $helper = new Diff();
         $lines = $helper->getLinePositions($diff);
 
-        return $lines[$line];
+        if ($lines !== null && array_key_exists($line, $lines)) {
+            return $lines[$line];
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: builder
Link to Bug: #877 

If the diff is empty, getLinePositions will return null - causing an offset notice.