### PR TITLE
Phpunit display fixes

### DIFF
--- a/public/assets/js/build-plugins/phpunit.js
+++ b/public/assets/js/build-plugins/phpunit.js
@@ -74,6 +74,8 @@ var phpunitPlugin = ActiveBuild.UiPlugin.extend({
 
             if (tests[i].message) {
                 message.text(tests[i].message);
+            } else if (tests[i].test && tests[i].suite) {
+                message.text(tests[i].suite + '::' + tests[i].test);
             } else {
                 message.html('<i>' + Lang.get('test_no_message') + '</i>');
             }

--- a/public/assets/js/build-plugins/phpunit.js
+++ b/public/assets/js/build-plugins/phpunit.js
@@ -68,18 +68,24 @@ var phpunitPlugin = ActiveBuild.UiPlugin.extend({
         var counts = { success: 0, fail: 0, error: 0, skipped: 0, todo: 0 }, total = 0;
 
         for (var i in tests) {
-            var severity = tests[i].severity || 'success',
-                message = tests[i].message || ('<i>' + Lang.get('test_no_message') + '</i>');
+            var content = $('<td colspan="3"></td>'),
+                message = $('<div></div>').appendTo(content),
+                severity = tests[i].severity || (tests[i].pass ? 'success' : 'failed');
+
+            if (tests[i].message) {
+                message.text(tests[i].message);
+            } else {
+                message.html('<i>' + Lang.get('test_no_message') + '</i>');
+            }
+
+            if (tests[i].data) {
+                content.append('<div>' + this.repr(tests[i].data) + '</div>');
+            }
+
+            $('<tr class="'+  severity + '"></tr>').append(content).appendTo(tbody);
+
             counts[severity]++;
             total++;
-            tbody.append(
-                '<tr class="'+  severity + '">' +
-                    '<td colspan="3">' +
-                        '<div>' + message + '</div>' +
-                        (tests[i].data ? '<div>' + this.repr(tests[i].data) + '</div>' : '') +
-                    '</td>' +
-                '</tr>'
-            );
         }
 
         var checkboxes = $('<th/>');


### PR DESCRIPTION
**Contribution Type:** bug fix
**Primary Area:** front-end

**Description of change:**
Fixes for two bugs introduced by #847:

1. Messages from PHPUnit aren't escaped for HTML.
1. Results preceding #847 aren't displayed properly.

**Description of solution:**

1. Use `.text(message)` instead of `.html(message)`.
1. Detect and use the `suite` and `test` attributes when the `message` attribute is undefined.
