### PR TITLE
Build removal safeguard

### DIFF
--- a/PHPCI/Model/Build.php
+++ b/PHPCI/Model/Build.php
@@ -221,10 +221,13 @@ class Build extends BuildBase
     /**
      * Return the path to run this build into.
      *
-     * @return string
+     * @return string|null
      */
     public function getBuildPath()
     {
+        if (!$this->getId()) {
+            return null;
+        }
         return PHPCI_BUILD_ROOT_DIR . $this->getId();
     }
 
@@ -235,7 +238,7 @@ class Build extends BuildBase
     {
         $buildPath = $this->getBuildPath();
 
-        if (!is_dir($buildPath)) {
+        if (!$buildPath || !is_dir($buildPath)) {
             return;
         }
 


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: builder

Description of change:

Fixing a potential bug introduced by #834: when deleting a build with no identifier, `Build::removeBuildDirectory` may try to remove the whole PHPCI/build tree. This should no happen in production, but it does happen in the tests.

Description of solution:

Have `Build::getBuildPath` returns null instead of an incorrect but valid path when the Build does not have an identifier (i.e. hasn't be persisted yet) and have `Build::removeBuildDirectory` double-checks the path.