### PR TITLE
Escape Technical Debt Plugin's Output #865

### DIFF
--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -190,7 +190,7 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
                 if (false !== $beforeString) {
                     $lines = explode(PHP_EOL, $beforeString);
                     $lineNumber = count($lines);
-                    $content = trim($allLines[$lineNumber - 1]);
+                    $content = htmlspecialchars(trim($allLines[$lineNumber - 1]));
 
                     $errorCount++;
                     $this->phpci->log("Found $search on line $lineNumber of $file:\n$content");


### PR DESCRIPTION
**Contribution Type:** bug fix 
**Primary Area:** front-end
**Link to Bug:** #865 

**Description of change:** Escape output of Technical Debt plugin

(Just getting used to git / pull request workflow; am I doing it right?)
