### PR TITLE
Fix for strict standards issue in RebuildCommand.php

### DIFF
--- a/PHPCI/Command/RebuildCommand.php
+++ b/PHPCI/Command/RebuildCommand.php
@@ -75,7 +75,8 @@ class RebuildCommand extends Command
         $store = Factory::getStore('Build');
         $service = new BuildService($store);
 
-        $lastBuild = array_shift($store->getLatestBuilds(null, 1));
+        $builds = $store->getLatestBuilds(null, 1);
+        $lastBuild = array_shift($builds);
         $service->createDuplicateBuild($lastBuild);
 
         $runner->run(new ArgvInput(array()), $output);


### PR DESCRIPTION
[ErrorException]                                                                                                                   
Runtime Notice: Only variables should be passed by reference in /var/www/phpci/PHPCI/Command/RebuildCommand.php line 78