### PR TITLE
CopyBuild Plugin: fixed wipe feature and added 'symlink to current build copy' feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ PHPCI/Store/MigrationStore.php
 PHPCI/Store/Base/MigrationStoreBase.php
 local_vars.php
 Tests/PHPCI/config.yml
-/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ PHPCI/Store/MigrationStore.php
 PHPCI/Store/Base/MigrationStoreBase.php
 local_vars.php
 Tests/PHPCI/config.yml
+/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ PHPCI/Store/MigrationStore.php
 PHPCI/Store/Base/MigrationStoreBase.php
 local_vars.php
 Tests/PHPCI/config.yml
+

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -1,12 +1,13 @@
 <?php
+
 /**
- * PHPCI - Continuous Integration for PHP
+ * PHPCI - Continuous Integration for PHP.
  *
  * @copyright    Copyright 2014, Block 8 Limited.
  * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ *
  * @link         https://www.phptesting.org/
  */
-
 namespace PHPCI\Plugin;
 
 use PHPCI\Builder;
@@ -14,11 +15,10 @@ use PHPCI\Model\Build;
 use PHPCI\Helper\Lang;
 
 /**
-* Copy Build Plugin - Copies the entire build to another directory.
-* @author       Dan Cryer <dan@block8.co.uk>
-* @package      PHPCI
-* @subpackage   Plugins
-*/
+ * Copy Build Plugin - Copies the entire build to another directory.
+ *
+ * @author       Dan Cryer <dan@block8.co.uk>
+ */
 class CopyBuild implements \PHPCI\Plugin
 {
     protected $directory;
@@ -30,9 +30,10 @@ class CopyBuild implements \PHPCI\Plugin
 
     /**
      * Set up the plugin, configure options, etc.
+     *
      * @param Builder $phpci
-     * @param Build $build
-     * @param array $options
+     * @param Build   $build
+     * @param array   $options
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
@@ -40,14 +41,14 @@ class CopyBuild implements \PHPCI\Plugin
         $this->phpci        = $phpci;
         $this->build = $build;
         $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
-        $this->wipe         = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
-        $this->ignore       = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;
+        $this->wipe         = isset($options['wipe']) ?  (bool) $options['wipe'] : false;
+        $this->ignore       = isset($options['respect_ignore']) ?  (bool) $options['respect_ignore'] : false;
         $this->symlink      = isset($options['symlink_to_current']) ? $options['symlink_to_current'] : false;
     }
 
     /**
-    * Copies files from the root of the build directory into the target folder
-    */
+     * Copies files from the root of the build directory into the target folder.
+     */
     public function execute()
     {
         $build = $this->phpci->buildPath;
@@ -70,12 +71,13 @@ class CopyBuild implements \PHPCI\Plugin
         if ($success && $this->symlink) {
             $success = $this->createSymlinkToCurrentBuild();
         }
-        
+
         return $success;
     }
 
     /**
      * Wipe the destination directory if it already exists.
+     *
      * @throws \Exception
      */
     protected function wipeExistingDirectory()
@@ -105,30 +107,31 @@ class CopyBuild implements \PHPCI\Plugin
             }
         }
     }
-     
+
     /**
      * Create symlink to current copy of build directory.
      * Info: Does not work on windows systems.
-     * @return boolean
+     *
+     * @return bool
      */
     protected function createSymlinkToCurrentBuild()
     {
         $success = true;
-        
+
         if (!IS_WIN) {
             $cmd = 'rm "%s" && ln -s "%s" "%s"';
-        
-            $dir = rtrim($this->directory, '/') . '/';
-            $this->phpci->log('Try to create symlink: '.$this->symlink.' --> '.$dir.$this->build->getId());
+
+            $dir = rtrim($this->directory, '/').'/';
+            $this->phpci->log('Try to create symlink '.$this->symlink.' --> '.$dir.$this->build->getId());
             $success = $this->phpci->executeCommand($cmd, $this->symlink, $dir.$this->build->getId(), $this->symlink);
-        
+
             if (!$success) {
-                $this->phpci->logFailure('Unable to create symlink: '.$this->symlink.' --> '.$dir.$this->build->getId());
+                $this->phpci->logFailure('Unable to create symlink.');
             } else {
-                 $this->phpci->log('Symlink successfully created.');
+                $this->phpci->log('Symlink successfully created.');
             }
         }
-        
+
         return $success;
     }
 }

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -41,10 +41,30 @@ class CopyBuild implements \PHPCI\Plugin
         $path               = $phpci->buildPath;
         $this->phpci        = $phpci;
         $this->build = $build;
-        $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
-        $this->wipe         = isset($options['wipe']) ?  (bool) $options['wipe'] : false;
-        $this->ignore       = isset($options['respect_ignore']) ?  (bool) $options['respect_ignore'] : false;
-        $this->symlink      = isset($options['symlink_to_current']) ? $options['symlink_to_current'] : false;
+        
+        if (isset($options['directory'])) {
+            $this->directory = $options['directory'];
+        } else {
+            $this->directory = $path;
+        }
+        
+        if (isset($options['wipe'])) {
+            $this->wipe = (bool) $options['wipe'];
+        } else {
+            $this->wipe = false;
+        }
+        
+        if (isset($options['respect_ignore'])) {
+            $this->ignore = (bool) $options['respect_ignore'];
+        } else {
+            $this->ignore = false;
+        }
+        
+        if (isset($options['symlink_to_current'])) {
+            $this->symlink = (bool) $options['respect_ignore'];
+        } else {
+            $this->symlink = false;
+        }
     }
 
     /**
@@ -120,7 +140,11 @@ class CopyBuild implements \PHPCI\Plugin
         $success = true;
 
         if (!IS_WIN) {
-            $cmd = 'rm "%s" && ln -s "%s" "%s"';
+            if (file_exists($this->symlink)) {
+                $cmd = 'rm "%s" && ln -s "%s" "%s"';
+            } else {
+                $cmd = 'ln -s "%s" "%s"';
+            }
 
             $dir = rtrim($this->directory, '/').'/';
             $this->phpci->log(sprintf('Try to create symlink %s --> %s', $this->symlink, $dir.$this->build->getId()));

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -83,7 +83,7 @@ class CopyBuild implements \PHPCI\Plugin
     protected function wipeExistingDirectory()
     {
         if ($this->wipe === true && $this->directory != '/' && is_dir($this->directory)) {
-            $cmd = 'rm -Rf "%s"*';
+            $cmd = 'rm -Rf "%s*"';
             $success = $this->phpci->executeCommand($cmd, $this->directory);
 
             if (!$success) {

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -83,7 +83,7 @@ class CopyBuild implements \PHPCI\Plugin
     protected function wipeExistingDirectory()
     {
         if ($this->wipe === true && $this->directory != '/' && is_dir($this->directory)) {
-            $cmd = 'rm -Rf %s*';
+            $cmd = 'rm -Rf "%s"*';
             $success = $this->phpci->executeCommand($cmd, $this->directory);
 
             if (!$success) {

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -26,6 +26,7 @@ class CopyBuild implements \PHPCI\Plugin
     protected $wipe;
     protected $phpci;
     protected $build;
+    protected $symlink;
 
     /**
      * Set up the plugin, configure options, etc.
@@ -41,6 +42,7 @@ class CopyBuild implements \PHPCI\Plugin
         $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
         $this->wipe         = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
         $this->ignore       = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;
+        $this->symlink      = isset($options['symlink_to_current']) ? $options['symlink_to_current'] : false;
     }
 
     /**
@@ -65,6 +67,10 @@ class CopyBuild implements \PHPCI\Plugin
 
         $this->deleteIgnoredFiles();
 
+        if ($success && $this->symlink) {
+            $success = $this->createSymlinkToCurrentBuild();
+        }
+        
         return $success;
     }
 
@@ -75,7 +81,7 @@ class CopyBuild implements \PHPCI\Plugin
     protected function wipeExistingDirectory()
     {
         if ($this->wipe === true && $this->directory != '/' && is_dir($this->directory)) {
-            $cmd = 'rm -Rf "%s*"';
+            $cmd = 'rm -Rf %s*';
             $success = $this->phpci->executeCommand($cmd, $this->directory);
 
             if (!$success) {
@@ -98,5 +104,31 @@ class CopyBuild implements \PHPCI\Plugin
                 $this->phpci->executeCommand($cmd, $this->directory, $file);
             }
         }
+    }
+     
+    /**
+     * Create symlink to current copy of build directory.
+     * Info: Does not work on windows systems.
+     * @return boolean
+     */
+    protected function createSymlinkToCurrentBuild()
+    {
+        $success = true;
+        
+        if (!IS_WIN) {
+            $cmd = 'rm "%s" && ln -s "%s" "%s"';
+        
+            $dir = rtrim($this->directory, '/') . '/';
+            $this->phpci->log('Try to create symlink: '.$this->symlink.' --> '.$dir.$this->build->getId());
+            $success = $this->phpci->executeCommand($cmd, $this->symlink, $dir.$this->build->getId(), $this->symlink);
+        
+            if (!$success) {
+                $this->phpci->logFailure('Unable to create symlink: '.$this->symlink.' --> '.$dir.$this->build->getId());
+            } else {
+                 $this->phpci->log('Symlink successfully created.');
+            }
+        }
+        
+        return $success;
     }
 }

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -5,9 +5,9 @@
  *
  * @copyright    Copyright 2014, Block 8 Limited.
  * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
- *
  * @link         https://www.phptesting.org/
  */
+
 namespace PHPCI\Plugin;
 
 use PHPCI\Builder;
@@ -15,10 +15,11 @@ use PHPCI\Model\Build;
 use PHPCI\Helper\Lang;
 
 /**
- * Copy Build Plugin - Copies the entire build to another directory.
- *
- * @author       Dan Cryer <dan@block8.co.uk>
- */
+* Copy Build Plugin - Copies the entire build to another directory.
+* @author       Dan Cryer <dan@block8.co.uk>, Stefan Rausch <srausch@skygate.de>
+* @package      PHPCI
+* @subpackage   Plugins
+*/
 class CopyBuild implements \PHPCI\Plugin
 {
     protected $directory;
@@ -122,7 +123,7 @@ class CopyBuild implements \PHPCI\Plugin
             $cmd = 'rm "%s" && ln -s "%s" "%s"';
 
             $dir = rtrim($this->directory, '/').'/';
-            $this->phpci->log('Try to create symlink '.$this->symlink.' --> '.$dir.$this->build->getId());
+            $this->phpci->log(sprintf('Try to create symlink %s --> %s', $this->symlink, $dir.$this->build->getId()));
             $success = $this->phpci->executeCommand($cmd, $this->symlink, $dir.$this->build->getId(), $this->symlink);
 
             if (!$success) {


### PR DESCRIPTION
- Added new option "symlink_to_current" (absolute path) to optionally create a symlink to the current build copy. This is useful for setting up a webserver for acceptance testing. By pointing to the symlink the document root never changes from build to build, whereas the path (including build number) changes with every build.
