### PR TITLE
Copyplugin wipe fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ PHPCI/Store/MigrationStore.php
 PHPCI/Store/Base/MigrationStoreBase.php
 local_vars.php
 Tests/PHPCI/config.yml
-/nbproject/


### PR DESCRIPTION
Moved "*" wildcard character out of the quotes, because within the quotes it gets escaped and is not used as wildcard anymore.
