### PR TITLE
Fixed error for some CLI scripts who uses stderr for some non-error messages

### DIFF
--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -108,18 +108,16 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
         $shouldOutput = ($this->logExecOutput && ($this->verbose || $status != 0));
 
-        if ($shouldOutput && !empty($this->lastOutput)) {
-            $this->logger->log($this->lastOutput);
-        }
-
-        if (!empty($this->lastError)) {
-            $this->logger->log("\033[0;31m" . $this->lastError . "\033[0m", LogLevel::ERROR);
-        }
-
         $rtn = false;
 
-        if ($status == 0) {
+        if ($status === 0) {
             $rtn = true;
+            if ($shouldOutput) {
+                $output = $this->lastOutput ?: $this->lastError;
+                $this->logger->log($output);
+            }
+        } else {
+            $this->logger->log("\033[0;31m" . $this->lastError . "\033[0m", LogLevel::ERROR);
         }
 
         return $rtn;


### PR DESCRIPTION
For example - Composer, Wget

To detect if some particular stderr content is really a error command executor should check exit status code, not the content of the stderr stream

References:

https://github.com/composer/composer/issues/3787
https://github.com/composer/composer/pull/3715