### PR TITLE
Application::handleRequest now properly displays exceptions.

### DIFF
--- a/PHPCI/Application.php
+++ b/PHPCI/Application.php
@@ -94,15 +94,21 @@ class Application extends b8\Application
                 $this->response->setContent($this->controller->layout->render());
             }
 
+            return $this->response;
+
+        } catch (\HttpException $ex) {
+            $this->response->setResponseCode($ex->getErrorCode());
         } catch (\Exception $ex) {
-            $this->config->set('page_title', 'Error');
-
-            $view = new View('exception');
-            $view->exception = $ex;
-
-            $this->response->setResponseCode($ex instanceof HttpException ? $ex->getErrorCode() : 500);
-            $this->response->setContent($view->render());
+            $this->response->setResponseCode(500);
         }
+
+        // We only get there if an excetion has been caught
+        $this->config->set('page_title', 'Error');
+
+        $view = new View('exception');
+        $view->exception = $ex;
+
+        $this->response->setContent($view->render());
 
         return $this->response;
     }

--- a/PHPCI/Application.php
+++ b/PHPCI/Application.php
@@ -86,29 +86,22 @@ class Application extends b8\Application
     {
         try {
             $this->response = parent::handleRequest();
-        } catch (HttpException $ex) {
-            $this->config->set('page_title', 'Error');
 
-            $view = new View('exception');
-            $view->exception = $ex;
+            if ($this->response->hasLayout() && $this->controller->layout) {
+                $this->setLayoutVariables($this->controller->layout);
 
-            $this->response->setResponseCode($ex->getErrorCode());
-            $this->response->setContent($view->render());
+                $this->controller->layout->content  = $this->response->getContent();
+                $this->response->setContent($this->controller->layout->render());
+            }
+
         } catch (\Exception $ex) {
             $this->config->set('page_title', 'Error');
 
             $view = new View('exception');
             $view->exception = $ex;
 
-            $this->response->setResponseCode(500);
+            $this->response->setResponseCode($ex instanceof HttpException ? $ex->getErrorCode() : 500);
             $this->response->setContent($view->render());
-        }
-
-        if ($this->response->hasLayout() && $this->controller->layout) {
-            $this->setLayoutVariables($this->controller->layout);
-
-            $this->controller->layout->content  = $this->response->getContent();
-            $this->response->setContent($this->controller->layout->render());
         }
 
         return $this->response;


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: front-end
Link to Bug: #960, #929, #719.

Description of change: properly display exceptions happening while handling a request.

Description of solution: modified Application::handleRequest.