### PR TITLE
Prevents getByLoginOrEmail from being erased by phpci:generate.

### DIFF
--- a/PHPCI/Store/Base/UserStoreBase.php
+++ b/PHPCI/Store/Base/UserStoreBase.php
@@ -82,30 +82,4 @@ class UserStoreBase extends Store
 
         return null;
     }
-    
-    /**
-     * Returns a User model by Email.
-     * @param string $value
-     * @param string $useConnection
-     * @throws HttpException
-     * @return \@appNamespace\Model\User|null
-     */
-    public function getByLoginOrEmail($value, $useConnection = 'read')
-    {
-        if (is_null($value)) {
-            throw new HttpException('Value passed to ' . __FUNCTION__ . ' cannot be null.');
-        }
-
-        $query = 'SELECT * FROM `user` WHERE `name` = :value OR `email` = :value LIMIT 1';
-        $stmt = Database::getConnection($useConnection)->prepare($query);
-        $stmt->bindValue(':value', $value);
-
-        if ($stmt->execute()) {
-            if ($data = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-                return new User($data);
-            }
-        }
-
-        return null;
-    }
 }

--- a/PHPCI/Store/UserStore.php
+++ b/PHPCI/Store/UserStore.php
@@ -19,5 +19,29 @@ use PHPCI\Store\Base\UserStoreBase;
 */
 class UserStore extends UserStoreBase
 {
-    // This class has been left blank so that you can modify it - changes in this file will not be overwritten.
+    /**
+     * Returns a User model by Email.
+     * @param string $value
+     * @param string $useConnection
+     * @throws HttpException
+     * @return \@appNamespace\Model\User|null
+     */
+    public function getByLoginOrEmail($value, $useConnection = 'read')
+    {
+        if (is_null($value)) {
+            throw new HttpException('Value passed to ' . __FUNCTION__ . ' cannot be null.');
+        }
+
+        $query = 'SELECT * FROM `user` WHERE `name` = :value OR `email` = :value LIMIT 1';
+        $stmt = Database::getConnection($useConnection)->prepare($query);
+        $stmt->bindValue(':value', $value);
+
+        if ($stmt->execute()) {
+            if ($data = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+                return new User($data);
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: ORM

getByLoginOrEmail has been added to UserStoreBase  in #873. However, this class is generated and overwritten by the phpci:generate command. The solution is to move it into UserStore, which should host such custom methods.