### PR TITLE
Fixed GithubBuild::getDiffLineNumber method for correct phpcpd work

### DIFF
--- a/PHPCI/Model/Build/GithubBuild.php
+++ b/PHPCI/Model/Build/GithubBuild.php
@@ -201,6 +201,8 @@ class GithubBuild extends RemoteGitBuild
      */
     protected function getDiffLineNumber(Builder $builder, $file, $line)
     {
+        $line = (integer)$line;
+
         $builder->logExecOutput(false);
 
         $prNumber = $this->getExtra('pull_request_number');


### PR DESCRIPTION
**Contribution Type:** bugfix
**Primary Area:** phpcpd plugin

**Description of change:**
On processing phpcpd output GithubBuild throw error:
```
Warning: Illegal offset type in .../GithubBuild.php line 224
```