### PR TITLE
Fixes notice in github builds

### DIFF
--- a/PHPCI/Model/Build/GithubBuild.php
+++ b/PHPCI/Model/Build/GithubBuild.php
@@ -221,6 +221,6 @@ class GithubBuild extends RemoteGitBuild
         $helper = new Diff();
         $lines = $helper->getLinePositions($diff);
 
-        return $lines[$line];
+        return isset($lines[$line]) ? $lines[$line] : null;
     }
 }


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: builder

Description of change: Added a check to see if the array key exists

    [2015-05-27 14:17:06] DaemoniseCommand.ERROR: Exception: Notice: Undefined offset: 40 in /Users/steverobbins/Project/PHPCI/PHPCI/Model/Build/GithubBuild.php line 224 {"exception":"[object] (ErrorException(code: 0): Notice: Undefined offset: 40 in /Users/steverobbins/Project/PHPCI/PHPCI/Model/Build/GithubBuild.php line 224 at /Users/steverobbins/Project/PHPCI/PHPCI/Model/Build/GithubBuild.php:224)","buildID":"9"} []
    [2015-05-27 14:17:09] DaemoniseCommand.ERROR: Exception: Notice: Undefined offset: 34 in /Users/steverobbins/Project/PHPCI/PHPCI/Model/Build/GithubBuild.php line 224 {"exception":"[object] (ErrorException(code: 0): Notice: Undefined offset: 34 in /Users/steverobbins/Project/PHPCI/PHPCI/Model/Build/GithubBuild.php line 224 at /Users/steverobbins/Project/PHPCI/PHPCI/Model/Build/GithubBuild.php:224)","buildID":"9"} []

Description of solution: Added a check to see if the array key exists