### PR TITLE
Pdepend Module: make check for Pdepend output dir more robust.

### DIFF
--- a/PHPCI/Plugin/Pdepend.php
+++ b/PHPCI/Plugin/Pdepend.php
@@ -73,8 +73,11 @@ class Pdepend implements \PHPCI\Plugin
      */
     public function execute()
     {
+        if (!file_exists($this->location)) {
+            mkdir($this->location);
+        }
         if (!is_writable($this->location)) {
-            throw new \Exception(sprintf('The location %s is not writable.', $this->location));
+            throw new \Exception(sprintf('The location %s is not writable or does not exist.', $this->location));
         }
 
         $pdepend = $this->phpci->findBinary('pdepend');


### PR DESCRIPTION
This fixes problems with the xml output directory by the pdfepend module.  Before this fix, the pdepend module would check for "is_writable". But the php function "is_writeable" not only returns false when the directory is not writable, but also if the target directory does not exist at all. The error message given by phpci:pdepend-module is misleading in these cases.
I suggest to a) attempt to create the dir if it does not exist, and b) make the error message more explanatory in case the dir cannot be created or is not accessible.