### PR TITLE
Contribution Type: improvement / new feature

### DIFF
--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -166,10 +166,11 @@ class Mysql implements \PHPCI\Plugin
         $args = array(
             ':import_file' => escapeshellarg($import_file),
             ':decomp_cmd' => $decomp_cmd,
+            ':host' => escapeshellarg($this->host),
             ':user' => escapeshellarg($this->user),
             ':pass' => escapeshellarg($this->pass),
             ':database' => ($database === null)? '': escapeshellarg($database),
         );
-        return strtr('cat :import_file :decomp_cmd | mysql -u:user -p:pass :database', $args);
+        return strtr('cat :import_file :decomp_cmd | mysql -h:host -u:user -p:pass :database', $args);
     }
 }


### PR DESCRIPTION
Primary Area: plugins

Description of change: Implemented using the same changes mentioned here: https://www.phptesting.org/forums/topic/5-mysql-plugin-setup/
Allows you to specify a hostname for your mysql connection.  Not my original code just patching it into the current source and made a branchs/push for it.

(i.e. Created a new plugin named ToolX, used library X to implement, see link)