### PR TITLE
Contribution Type: bugfix

### DIFF
--- a/PHPCI/Plugin/Util/TapParser.php
+++ b/PHPCI/Plugin/Util/TapParser.php
@@ -13,9 +13,10 @@ use Symfony\Component\Yaml\Yaml;
 class TapParser
 {
     const TEST_COUNTS_PATTERN = '/^\d+\.\.(\d+)/';
-    const TEST_LINE_PATTERN = '/^(ok|not ok)(?:\s+\d+)?(?:\s+\-)?\s*(.*?)(?:\s*#\s*(skip|todo)\s*(.*))?\s*$/i';
-    const TEST_YAML_START = '/^(\s*)---/';
-    const TEST_DIAGNOSTIC = '/^#/';
+    const TEST_LINE_PATTERN   = '/^(ok|not ok)(?:\s+\d+)?(?:\s+\-)?\s*(.*?)(?:\s*#\s*(skip|todo)\s*(.*))?\s*$/i';
+    const TEST_YAML_START     = '/^(\s*)---/';
+    const TEST_DIAGNOSTIC     = '/^#/';
+    const TEST_COVERAGE       = '/^Generating/';
 
     /**
      * @var string
@@ -81,7 +82,7 @@ class TapParser
             $line = $this->nextLine();
         }
 
-        if (count($this->results) !== $this->testCount) {
+        if (false !== $this->testCount && count($this->results) !== $this->testCount) {
             throw new Exception(Lang::get('tap_error'));
         }
 
@@ -123,19 +124,14 @@ class TapParser
         return false;
     }
 
-    /** Parse a single line.
-     *
+    /**
      * @param string $line
+     *
+     * @return boolean
      */
-    protected function parseLine($line)
+    protected function testLine($line)
     {
-        if (preg_match(self::TEST_COUNTS_PATTERN, $line, $matches)) {
-            $this->testCount = intval($matches[1]);
-
-        } elseif (preg_match(self::TEST_DIAGNOSTIC, $line)) {
-            return;
-
-        } elseif (preg_match(self::TEST_LINE_PATTERN, $line, $matches)) {
+        if (preg_match(self::TEST_LINE_PATTERN, $line, $matches)) {
             $this->results[] = $this->processTestLine(
                 $matches[1],
                 isset($matches[2]) ? $matches[2] : '',
@@ -143,18 +139,61 @@ class TapParser
                 isset($matches[4]) ? $matches[4] : null
             );
 
-        } elseif (preg_match(self::TEST_YAML_START, $line, $matches)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $line
+     *
+     * @return boolean
+     */
+    protected function yamlLine($line)
+    {
+        if (preg_match(self::TEST_YAML_START, $line, $matches)) {
             $diagnostic = $this->processYamlBlock($matches[1]);
-            $test = array_pop($this->results);
+            $test       = array_pop($this->results);
             if (isset($test['message'], $diagnostic['message'])) {
                 $test['message'] .= PHP_EOL . $diagnostic['message'];
                 unset($diagnostic['message']);
             }
             $this->results[] = array_replace($test, $diagnostic);
 
-        } else {
-            throw new Exception(sprintf('Incorrect TAP data, line %d: %s', $this->lineNumber, $line));
+            return true;
         }
+
+        return false;
+    }
+
+    /** Parse a single line.
+     *
+     * @param string $line
+     *
+     * @throws Exception
+     */
+    protected function parseLine($line)
+    {
+        if (preg_match(self::TEST_DIAGNOSTIC, $line) || preg_match(self::TEST_COVERAGE, $line) || !$line) {
+            return;
+        }
+
+        if (preg_match(self::TEST_COUNTS_PATTERN, $line, $matches)) {
+            $this->testCount = intval($matches[1]);
+
+            return;
+        }
+
+        if ($this->testLine($line)) {
+            return;
+        }
+
+        if ($this->yamlLine($line)) {
+            return;
+        }
+
+        throw new Exception(sprintf('Incorrect TAP data, line %d: %s', $this->lineNumber, $line));
     }
 
     /**

--- a/Tests/PHPCI/Plugin/Util/TapParserTest.php
+++ b/Tests/PHPCI/Plugin/Util/TapParserTest.php
@@ -35,6 +35,28 @@ TAP;
         $this->assertEquals(1, $parser->getTotalFailures());
     }
 
+    public function testSimple2()
+    {
+        $content = <<<TAP
+Leading garbage !
+TAP version 13
+
+ok 1 - SomeTest::testAnother
+not ok
+1..2
+
+TAP;
+        $parser = new TapParser($content);
+        $result = $parser->parse();
+
+        $this->assertEquals(array(
+            array('pass' => true, 'severity' => 'success', 'message' => 'SomeTest::testAnother'),
+            array('pass' => false, 'severity' => 'fail', 'message' => ''),
+        ), $result);
+
+        $this->assertEquals(1, $parser->getTotalFailures());
+    }
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessageRegExp /No TAP/
@@ -46,6 +68,20 @@ Only garbage !
 TAP;
         $parser = new TapParser($content);
         $parser->parse();
+    }
+
+    public function testTapCoverage()
+    {
+        $content = <<<TAP
+TAP version 13
+
+Generating code coverage report in HTML format ... done
+
+TAP;
+        $parser = new TapParser($content);
+        $result = $parser->parse();
+
+        $this->assertEquals(array(), $result);
     }
 
     /**


### PR DESCRIPTION
Primary Area: TapParser (PHPUnit plugin)

Description of change:
Tap parser failed on valid phpunit output (No tests and enabled code coverage):

Not my Changes, these belong to https://github.com/corpsee who orginally submitted them