### PR TITLE
Fixed a css issue with Block8 logo

### DIFF
--- a/PHPCI/View/Session.phtml
+++ b/PHPCI/View/Session.phtml
@@ -67,6 +67,14 @@
             bottom: 50px;
             right: 50px;
         }
+        
+        @media(max-width:767px) { 
+            #logo {
+                position: inherit;
+                margin: 0 auto;
+                margin-top: 50px;
+            }
+        }
 
         #logo:hover {
             background-image: url('https://www.block8.co.uk/assets/images/b8-phpci-logo.png');


### PR DESCRIPTION
In Chrome (Android L), when you focus an input, the Block8 logo overrides the view.
See : http://s10.postimg.org/d5ffp7dwp/2015_06_30_07_57_03.png