### PR TITLE
Update PhpCsFixer plugin

### DIFF
--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -32,10 +32,10 @@ class PhpCsFixer implements \PHPCI\Plugin
     protected $build;
 
     protected $workingDir = '';
-    protected $level      = ' --level=all';
+    protected $level      = ' --level=psr2';
     protected $verbose    = '';
     protected $diff       = '';
-    protected $levels     = array('psr0', 'psr1', 'psr2', 'all');
+    protected $levels     = array('psr0', 'psr1', 'psr2', 'symfony');
 
     /**
      * Standard Constructor


### PR DESCRIPTION
Update the PhpCsFixer plugin to work with the latest version of php-cs-fixer.

Also added the `--dry-run` option as it does not need to apply the change in the build directory.

This fixes https://github.com/Block8/PHPCI/issues/833