### PR TITLE
Fix missing path in technical debt plugin

### DIFF
--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -145,7 +145,7 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
      */
     public function getErrorList()
     {
-        $dirIterator = new \RecursiveDirectoryIterator($this->directory);
+        $dirIterator = new \RecursiveDirectoryIterator($this->directory . DIRECTORY_SEPARATOR . $this->path);
         $iterator = new \RecursiveIteratorIterator($dirIterator, \RecursiveIteratorIterator::SELF_FIRST);
         $files = array();
 


### PR DESCRIPTION
The technical debt plugin is always executed on the root dir. This PR fixes this.
