### PR TITLE
MySQL alternative port support

### DIFF
--- a/PHPCI/Command/GenerateCommand.php
+++ b/PHPCI/Command/GenerateCommand.php
@@ -12,7 +12,7 @@ namespace PHPCI\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use b8\Database;
+use PHPCI\Database;
 use b8\Database\CodeGenerator;
 
 /**

--- a/PHPCI/Command/InstallCommand.php
+++ b/PHPCI/Command/InstallCommand.php
@@ -250,7 +250,7 @@ class InstallCommand extends Command
         $dialog = $this->getHelperSet()->get('dialog');
 
         if (!$dbHost = $input->getOption('db-host')) {
-            $dbHost = $dialog->ask($output, Lang::get('enter_db_host'), 'localhost');
+            $dbHost = $dialog->ask($output, Lang::get('enter_db_host'), 'localhost:3306');
         }
 
         if (!$dbName = $input->getOption('db-name')) {
@@ -283,8 +283,15 @@ class InstallCommand extends Command
     protected function verifyDatabaseDetails(array $db, OutputInterface $output)
     {
         try {
+            if (strpos($db['servers']['write'], ':') !== false) {
+                list($host, $port) = explode(':', $db['servers']['write']);
+                $dsn = 'mysql:host=' . $host . ';port=' . $port;
+            } else {
+                $dsn = 'mysql:host=' . $db['servers']['write'];
+            }
+
             $pdo = new PDO(
-                'mysql:host='.$db['servers']['write'].';dbname='.$db['name'],
+                $dsn . ';dbname='.$db['name'],
                 $db['username'],
                 $db['password'],
                 array(

--- a/PHPCI/Database.php
+++ b/PHPCI/Database.php
@@ -1,0 +1,83 @@
+<?php
+namespace PHPCI;
+
+use b8\Database as B8Database;
+
+class Database extends B8Database
+{
+    public static function getConnection($type = 'read')
+    {
+        if (!self::$initialised) {
+            self::init();
+        }
+
+        // If the connection hasn't been used for 5 minutes, force a reconnection:
+        if (!is_null(self::$lastUsed[$type]) && (time() - self::$lastUsed[$type]) > 300) {
+            self::$connections[$type] = null;
+        }
+
+        if(is_null(self::$connections[$type]))
+        {
+            if (is_array(self::$servers[$type])) {
+                // Shuffle, so we pick a random server
+                $servers = self::$servers[$type];
+                shuffle($servers);
+            } else {
+                // Only one server was specified
+                $servers = array(self::$servers[$type]);
+            }
+
+            $connection = null;
+
+            // Loop until we get a working connection:
+            while(count($servers))
+            {
+                // Pull the next server:
+                $server = array_shift($servers);
+
+                // Try to connect:
+                try
+                {
+                    // Check if host contains a port
+                    if (strpos($server, ':') !== false) {
+                        list($host, $port) = explode(':', $server);
+                        $dsn = 'mysql:host=' . $host . ';port=' . $port;
+                    } else {
+                        $dsn = 'mysql:host=' . $server;
+                    }
+
+                    $connection = new self($dsn . ';dbname=' . self::$details['db'],
+                        self::$details['user'],
+                        self::$details['pass'],
+                        array(
+                            \PDO::ATTR_PERSISTENT         => false,
+                            \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
+                            \PDO::ATTR_TIMEOUT            => 2,
+                            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES \'UTF8\'',
+                        ));
+                }
+                catch(\PDOException $ex)
+                {
+                    $connection = false;
+                }
+
+                // Opened a connection? Break the loop:
+                if($connection)
+                {
+                    break;
+                }
+            }
+
+            // No connection? Oh dear.
+            if(!$connection && $type == 'read')
+            {
+                throw new \Exception('Could not connect to any ' . $type . ' servers.');
+            }
+
+            self::$connections[$type] = $connection;
+        }
+
+        self::$lastUsed[$type] = time();
+        return self::$connections[$type];
+    }
+} 

--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -10,6 +10,7 @@
 namespace PHPCI\Plugin;
 
 use PDO;
+use PHPCI\Database;
 use PHPCI\Builder;
 use PHPCI\Helper\Lang;
 use PHPCI\Model\Build;
@@ -65,7 +66,7 @@ class Mysql implements \PHPCI\Plugin
 
         $this->queries = $options;
 
-        $config = \b8\Database::getConnection('write')->getDetails();
+        $config = Database::getConnection('write')->getDetails();
 
         $this->host =(defined('PHPCI_DB_HOST')) ? PHPCI_DB_HOST : null;
         $this->user = $config['user'];
@@ -98,7 +99,15 @@ class Mysql implements \PHPCI\Plugin
     {
         try {
             $opts = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
-            $pdo  = new PDO('mysql:host=' . $this->host, $this->user, $this->pass, $opts);
+
+            if (strpos($this->host, ':') !== false) {
+                list($host, $port) = explode(':', $this->host);
+                $dsn = 'mysql:host=' . $host . ';port=' . $port;
+            } else {
+                $dsn = 'mysql:host=' . $this->host;
+            }
+
+            $pdo  = new PDO($dsn, $this->user, $this->pass, $opts);
 
             foreach ($this->queries as $query) {
                 if (!is_array($query)) {

--- a/PHPCI/Store/Base/BuildMetaStoreBase.php
+++ b/PHPCI/Store/Base/BuildMetaStoreBase.php
@@ -6,8 +6,8 @@
 
 namespace PHPCI\Store\Base;
 
-use b8\Database;
 use b8\Exception\HttpException;
+use PHPCI\Database;
 use PHPCI\Store;
 use PHPCI\Model\BuildMeta;
 

--- a/PHPCI/Store/Base/BuildStoreBase.php
+++ b/PHPCI/Store/Base/BuildStoreBase.php
@@ -6,8 +6,8 @@
 
 namespace PHPCI\Store\Base;
 
-use b8\Database;
 use b8\Exception\HttpException;
+use PHPCI\Database;
 use PHPCI\Store;
 use PHPCI\Model\Build;
 

--- a/PHPCI/Store/Base/ProjectStoreBase.php
+++ b/PHPCI/Store/Base/ProjectStoreBase.php
@@ -6,8 +6,8 @@
 
 namespace PHPCI\Store\Base;
 
-use b8\Database;
 use b8\Exception\HttpException;
+use PHPCI\Database;
 use PHPCI\Store;
 use PHPCI\Model\Project;
 

--- a/PHPCI/Store/Base/UserStoreBase.php
+++ b/PHPCI/Store/Base/UserStoreBase.php
@@ -6,8 +6,8 @@
 
 namespace PHPCI\Store\Base;
 
-use b8\Database;
 use b8\Exception\HttpException;
+use PHPCI\Database;
 use PHPCI\Store;
 use PHPCI\Model\User;
 

--- a/PHPCI/Store/BuildStore.php
+++ b/PHPCI/Store/BuildStore.php
@@ -9,7 +9,7 @@
 
 namespace PHPCI\Store;
 
-use b8\Database;
+use PHPCI\Database;
 use PHPCI\Model\Build;
 use PHPCI\Store\Base\BuildStoreBase;
 

--- a/PHPCI/Store/ProjectStore.php
+++ b/PHPCI/Store/ProjectStore.php
@@ -9,7 +9,7 @@
 
 namespace PHPCI\Store;
 
-use b8\Database;
+use PHPCI\Database;
 use PHPCI\Model\Project;
 use PHPCI\Store\Base\ProjectStoreBase;
 


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: Database
Link to Intent to Implement: https://github.com/Block8/PHPCI/issues/1037
Link to Bug: https://github.com/Block8/PHPCI/issues/1037

Description of change:
Added support for alternative mysql port (localhost:3306).

Description of solution:
Port number can be specified in the hostname like so, hostname:port
eg. localhost:3306