### PR TITLE
Reflow the plugin boxes

### DIFF
--- a/public/assets/js/build.js
+++ b/public/assets/js/build.js
@@ -62,7 +62,7 @@ var Build = Class.extend({
     storePluginOrder: function () {
         var renderOrder = [];
 
-        $('.ui-plugin > div').each(function() {
+        $('.ui-plugin').each(function() {
             renderOrder.push($(this).attr('id'));
         });
 
@@ -108,8 +108,8 @@ var Build = Class.extend({
             output = $('<div class="box-body"></div>').append(output);
         }
 
-        var container = $('<div></div>').addClass('ui-plugin ' + plugin.css);
-        var content = $('<div></div>').attr('id', plugin.id).append(output);
+        var container = $('<div></div>').addClass('ui-plugin ' + plugin.css).attr('id', plugin.id);
+        var content = $('<div></div>').append(output);
         content.addClass('box box-default');
 
         if (plugin.title) {

--- a/public/assets/js/build.js
+++ b/public/assets/js/build.js
@@ -95,6 +95,7 @@ var Build = Class.extend({
         $('#plugins').sortable({
             handle: '.box-title',
             connectWith: '#plugins',
+            cursorAt: { top: 15, left: 25 },
             update: self.storePluginOrder
         });
 


### PR DESCRIPTION
Contribution Type: bug fix/cosmetic
Primary Area: front-end

Description: The not used plugin boxes simply hide their content, but are included in the layout (because only the content is hidden, not the box itself). Therefore the remaining visible boxes can not flow properly.
Description of solution: The id now is assigned to the box itself, not only the content. This way the hidden boxes are excluded from the layout and the visible boxes can catch up. See below for a comparison.

**Before**

![before](https://cloud.githubusercontent.com/assets/1307920/8918493/89aef95e-34b8-11e5-8b9e-c54fc132e35d.jpg)


**After**

![after](https://cloud.githubusercontent.com/assets/1307920/8918494/89af364e-34b8-11e5-87b3-2a9d4abb0dd1.jpg)
