### PR TITLE
Colorize phpmd warnings based on priority

### DIFF
--- a/public/assets/js/build-plugins/phpmd.js
+++ b/public/assets/js/build-plugins/phpmd.js
@@ -70,6 +70,12 @@ var phpmdPlugin = ActiveBuild.UiPlugin.extend({
                 '<td>'+errors[i].line_end+'</td>' +
                 '<td>'+errors[i].message+'</td></tr>');
 
+            if (errors[i].priority == 1) {
+                row.addClass('danger');
+            } else if (errors[i].priority == 2) {
+                row.addClass('warning');
+            }
+
             tbody.append(row);
         }
 


### PR DESCRIPTION
Contribution Type: cosmetic
Primary Area: front-end

Description of change: The PHP Mess Detector warnings now have a background color, based on the priority of the rule (red for priority 1, yellow for priority 2, white for priority 3).