### PR TITLE
Display accurate build status at any point

### DIFF
--- a/Tests/PHPCI/Controller/BuildStatusControllerTest.php
+++ b/Tests/PHPCI/Controller/BuildStatusControllerTest.php
@@ -10,16 +10,20 @@
 
 namespace Tests\PHPCI\Controller;
 
+use PHPCI\Model\Build;
+
 class BuildStatusControllerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @dataProvider getImageColorFromStatusDataProvider
+     * @dataProvider getImageTextAndColorFromStatusDataProvider
      *
      * @param string $status
+     * @param string $expectedText
      * @param string $expectedColor
      */
-    public function testGetImageColorFromStatusReturnsTheCorrectColorForEachStatus(
+    public function testGetImageTextAndColorFromStatusReturnsTheCorrectTextAndColorForEachStatus(
         $status,
+        $expectedText,
         $expectedColor
     ) {
         $buildStatusControllerMock =
@@ -32,24 +36,25 @@ class BuildStatusControllerTest extends \PHPUnit_Framework_TestCase
             new \ReflectionClass('PHPCI\Controller\BuildStatusController');
 
         $getImageColorFromStatusReflection =
-            $buildStatusControllerReflection->getMethod('getImageColorFromStatus');
+            $buildStatusControllerReflection->getMethod('getImageTextAndColorFromStatus');
         $getImageColorFromStatusReflection->setAccessible(true);
 
-        $this->assertEquals(
-            $expectedColor,
-            $getImageColorFromStatusReflection->invoke($buildStatusControllerMock, $status)
-        );
+        list($text, $color) = $getImageColorFromStatusReflection->invoke($buildStatusControllerMock, $status);
+
+        $this->assertEquals($expectedText, $text);
+        $this->assertEquals($expectedColor, $color);
     }
 
-    public function getImageColorFromStatusDataProvider()
+    /**
+     * @return array
+     */
+    public function getImageTextAndColorFromStatusDataProvider()
     {
         return array(
-            array('passing', 'green'),
-            array('running', 'orange'),
-            array('failed', 'red'),
-            array('error', 'red'),
-            array('unknown', 'lightgrey'),
-            array('test the default case', 'lightgrey'),
+            array(Build::STATUS_NEW, 'pending', 'blue'),
+            array(Build::STATUS_RUNNING, 'running', 'yellow'),
+            array(Build::STATUS_SUCCESS, 'success', 'green'),
+            array(Build::STATUS_FAILED, 'failed', 'red'),
         );
     }
 }

--- a/Tests/PHPCI/Controller/BuildStatusControllerTest.php
+++ b/Tests/PHPCI/Controller/BuildStatusControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * PHPCI - Continuous Integration for PHP
+ *
+ * @copyright    Copyright 2014, Block 8 Limited.
+ * @license      https://github.com/Block8/PHPCI/blob/master/LICENSE.md
+ * @link         https://www.phptesting.org/
+ */
+
+namespace Tests\PHPCI\Controller;
+
+class BuildStatusControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getImageColorFromStatusDataProvider
+     *
+     * @param string $status
+     * @param string $expectedColor
+     */
+    public function testGetImageColorFromStatusReturnsTheCorrectColorForEachStatus(
+        $status,
+        $expectedColor
+    ) {
+        $buildStatusControllerMock =
+            $this->getMockBuilder('PHPCI\Controller\BuildStatusController')
+                 ->disableOriginalConstructor()
+                 ->setMethods(null)
+                 ->getMock();
+
+        $buildStatusControllerReflection =
+            new \ReflectionClass('PHPCI\Controller\BuildStatusController');
+
+        $getImageColorFromStatusReflection =
+            $buildStatusControllerReflection->getMethod('getImageColorFromStatus');
+        $getImageColorFromStatusReflection->setAccessible(true);
+
+        $this->assertEquals(
+            $expectedColor,
+            $getImageColorFromStatusReflection->invoke($buildStatusControllerMock, $status)
+        );
+    }
+
+    public function getImageColorFromStatusDataProvider()
+    {
+        return array(
+            array('passing', 'green'),
+            array('running', 'orange'),
+            array('failed', 'red'),
+            array('error', 'red'),
+            array('unknown', 'lightgrey'),
+            array('test the default case', 'lightgrey'),
+        );
+    }
+}


### PR DESCRIPTION
Currently, after pushing a new commit if a user asks for the status image, the displayed status will be either failing or passing, based on the previous commit, even if the current build has not completed. 

If the status image is linked somewhere (we use a chrome plugin to embed this image automatically on all our Bitbucket pull requests) most of the time the build is shown as passing, until the actual build completes, and the image is updated.

This causes issues as the build takes a while to complete, and developers have to manually check the PHPCI interface for any running builds before actually trusting the image. I think this defeats the purpose of the badge.

This pull request adds 2 more statuses for the badge (not the build):
- unknown (build is created but is not being executed yet), light grey color
- running (build is being executed by the daemon or cron task), orange color

This displays the actual state of a branch at any point, avoiding to have to manually check for any running builds
