### PR TITLE
PHP CS Fixer - fix name

### DIFF
--- a/PHPCI/Plugin/PhpCsFixer.php
+++ b/PHPCI/Plugin/PhpCsFixer.php
@@ -14,7 +14,7 @@ use PHPCI\Helper\Lang;
 use PHPCI\Model\Build;
 
 /**
-* PHP CS Fixer - Works with the PHP CS Fixer for testing coding standards.
+* PHP CS Fixer - Works with the PHP Coding Standards Fixer for testing coding standards.
 * @author       Gabriel Baker <gabriel@autonomicpilot.co.uk>
 * @package      PHPCI
 * @subpackage   Plugins

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "sebastian/phpcpd": "PHP Copy/Paste Detector",
         "squizlabs/php_codesniffer": "PHP Code Sniffer",
         "phpspec/phpspec": "PHP Spec",
-        "fabpot/php-cs-fixer": "PHP Code Sniffer Fixer",
+        "fabpot/php-cs-fixer": "PHP Coding Standards Fixer",
         "phploc/phploc": "PHP Lines of Code",
         "atoum/atoum": "Atoum",
         "jakub-onderka/php-parallel-lint": "Parallel Linting Tool",


### PR DESCRIPTION
PHP Coding Standards Fixer

Contribution Type: cosmetic
Primary Area: plugins

Description of change:
Project has wrong full name of PHP CS Fixer, which is `PHP Coding Standards Fixer`, not `PHP Code Sniffer Fixer`