### PR TITLE
Add Project Property to Build Default Branch Only

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -220,6 +220,7 @@ class ProjectController extends PHPCI\Controller
                 'build_config' => $this->getParam('build_config', null),
                 'allow_public_status' => $this->getParam('allow_public_status', 0),
                 'branch' => $this->getParam('branch', null),
+                'default_branch_only' => $this->getParam('default_branch_only', 0),
             );
 
             $project = $this->projectService->createProject($title, $type, $reference, $options);
@@ -284,6 +285,7 @@ class ProjectController extends PHPCI\Controller
             'allow_public_status' => $this->getParam('allow_public_status', 0),
             'archived' => $this->getParam('archived', 0),
             'branch' => $this->getParam('branch', null),
+            'default_branch_only' => $this->getParam('default_branch_only', 0),
         );
 
         $project = $this->projectService->updateProject($project, $title, $type, $reference, $options);
@@ -350,6 +352,12 @@ class ProjectController extends PHPCI\Controller
 
         $field = Form\Element\Text::create('branch', Lang::get('default_branch'), true);
         $field->setClass('form-control')->setContainerClass('form-group')->setValue('master');
+        $form->addField($field);
+
+        $field = Form\Element\Checkbox::create('default_branch_only', Lang::get('default_branch_only'), false);
+        $field->setContainerClass('form-group');
+        $field->setCheckedValue(1);
+        $field->setValue(0);
         $form->addField($field);
 
         $field = Form\Element\Checkbox::create('allow_public_status', Lang::get('allow_public_status'), false);

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -362,6 +362,11 @@ class WebhookController extends \b8\Controller
             );
         }
 
+        // Check if this branch is to be built.
+        if ($project->getDefaultBranchOnly() && $branch != $project->getBranch()) {
+            return true;
+        }
+
         // If not, create a new build job for it:
         $build = $this->buildService->createBuild($project, $commitId, $branch, $committer, $commitMessage, $extra);
         $build = BuildFactory::getBuild($build);

--- a/PHPCI/Languages/lang.en.php
+++ b/PHPCI/Languages/lang.en.php
@@ -114,6 +114,7 @@ PHPCI',
     'build_config' => 'PHPCI build config for this project
                                 (if you cannot add a phpci.yml file in the project repository)',
     'default_branch' => 'Default branch name',
+    'default_branch_only' => 'Build default branch only',
     'allow_public_status' => 'Enable public status page and image for this project?',
     'archived' => 'Archived',
     'save_project' => 'Save Project',

--- a/PHPCI/Migrations/20150901144444_add_default_branch_build.php
+++ b/PHPCI/Migrations/20150901144444_add_default_branch_build.php
@@ -1,0 +1,30 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddDefaultBranchBuild extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $dbAdapter = $this->getAdapter();
+
+        if ($dbAdapter instanceof \Phinx\Db\Adapter\PdoAdapter) {
+            $pdo = $dbAdapter->getConnection();
+            $pdo->exec('SET foreign_key_checks = 0');
+        }
+
+        $project = $this->table('project');
+
+        if (!$project->hasColumn('default_branch_only')) {
+            $table->addColumn('default_branch_only', 'integer');
+        }
+
+        if ($dbAdapter instanceof \Phinx\Db\Adapter\PdoAdapter) {
+            $pdo = $dbAdapter->getConnection();
+            $pdo->exec('SET foreign_key_checks = 1');
+        }
+    }
+}

--- a/PHPCI/Model/Base/ProjectBase.php
+++ b/PHPCI/Model/Base/ProjectBase.php
@@ -44,6 +44,7 @@ class ProjectBase extends Model
         'build_config' => null,
         'ssh_public_key' => null,
         'allow_public_status' => null,
+        'default_branch_only' => null,
         'archived' => null,
     );
 
@@ -63,6 +64,7 @@ class ProjectBase extends Model
         'build_config' => 'getBuildConfig',
         'ssh_public_key' => 'getSshPublicKey',
         'allow_public_status' => 'getAllowPublicStatus',
+        'default_branch_only' => 'getDefaultBranchOnly',
         'archived' => 'getArchived',
 
         // Foreign key getters:
@@ -84,6 +86,7 @@ class ProjectBase extends Model
         'build_config' => 'setBuildConfig',
         'ssh_public_key' => 'setSshPublicKey',
         'allow_public_status' => 'setAllowPublicStatus',
+        'default_branch_only' => 'setDefaultBranchOnly',
         'archived' => 'setArchived',
 
         // Foreign key setters:
@@ -148,6 +151,10 @@ class ProjectBase extends Model
             'default' => null,
         ),
         'allow_public_status' => array(
+            'type' => 'int',
+            'length' => 11,
+        ),
+        'default_branch_only' => array(
             'type' => 'int',
             'length' => 11,
         ),
@@ -301,6 +308,18 @@ class ProjectBase extends Model
     public function getAllowPublicStatus()
     {
         $rtn    = $this->data['allow_public_status'];
+
+        return $rtn;
+    }
+
+    /**
+    * Get the value of DefaultBranchOnly / default_branch_only.
+    *
+    * @return int
+    */
+    public function getDefaultBranchOnly()
+    {
+        $rtn    = $this->data['default_branch_only'];
 
         return $rtn;
     }
@@ -525,6 +544,26 @@ class ProjectBase extends Model
         $this->data['allow_public_status'] = $value;
 
         $this->_setModified('allow_public_status');
+    }
+
+     /**
+    * Set the value of DefaultBranchOnly / default_branch_only.
+    *
+    * Must not be null.
+    * @param $value int
+    */
+    public function setDefaultBranchOnly($value)
+    {
+        $this->_validateNotNull('DefaultBranchOnly', $value);
+        $this->_validateInt('DefaultBranchOnly', $value);
+
+        if ($this->data['default_branch_only'] === $value) {
+            return;
+        }
+
+        $this->data['default_branch_only'] = $value;
+
+        $this->_setModified('default_branch_only');
     }
 
     /**

--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -63,6 +63,7 @@ class ProjectService
         $project->setType($type);
         $project->setReference($reference);
         $project->setAllowPublicStatus(0);
+        $project->setDefaultBranchOnly(0);
 
         // Handle extra project options:
         if (array_key_exists('ssh_private_key', $options)) {
@@ -87,6 +88,10 @@ class ProjectService
 
         if (array_key_exists('branch', $options)) {
             $project->setBranch($options['branch']);
+        }
+
+        if (array_key_exists('default_branch_only', $options)) {
+            $project->setDefaultBranchOnly((int)$options['default_branch_only']);
         }
 
         // Allow certain project types to set access information:


### PR DESCRIPTION
This modification adds a checkbox to the project settings page to only build the branch specified in the Default Branch field.

The value is saved in an additional column in the 'project' database.

When a web hook comes in, the createBuild method first checks if the project is to only build the default branch, and then if the branch name in the web hook request matches the default branch name. If not, the build is not added to the queue.

I am not clear on how the "Migrations" scripts are executed, but I added a commit with one anyway. It should create the correct column in the database.

This pull request addresses most of issue #574, which we found to be most annoying with many developers with private branches, and a phpunit build that takes 2.5 hours.
