### PR TITLE
Adding support to check for .phpci.yml so the file can be 'hidden'

### DIFF
--- a/PHPCI/Model/Build.php
+++ b/PHPCI/Model/Build.php
@@ -99,14 +99,14 @@ class Build extends BuildBase
     {
         $build_config = null;
 
-        // Try phpci.yml first:
-        if (is_file($buildPath . '/phpci.yml')) {
-            $build_config = file_get_contents($buildPath . '/phpci.yml');
+        // Try .phpci.yml
+        if (is_file($buildPath . '/.phpci.yml')) {
+            $build_config = file_get_contents($buildPath . '/.phpci.yml');
         }
 
-        // Try .phpci.yml
-        if (empty($build_config) && is_file($buildPath . '/.phpci.yml')) {
-            $build_config = file_get_contents($buildPath . '/.phpci.yml');
+        // Try phpci.yml first:
+        if (empty($build_config) && is_file($buildPath . '/phpci.yml')) {
+            $build_config = file_get_contents($buildPath . '/phpci.yml');
         }
 
         // Try getting the project build config from the database:

--- a/PHPCI/Model/Build.php
+++ b/PHPCI/Model/Build.php
@@ -104,6 +104,11 @@ class Build extends BuildBase
             $build_config = file_get_contents($buildPath . '/phpci.yml');
         }
 
+        // Try .phpci.yml
+        if (empty($build_config) && is_file($buildPath . '/.phpci.yml')) {
+            $build_config = file_get_contents($buildPath . '/.phpci.yml');
+        }
+
         // Try getting the project build config from the database:
         if (empty($build_config)) {
             $build_config = $this->getProject()->getBuildConfig();

--- a/PHPCI/Plugin/TechnicalDebt.php
+++ b/PHPCI/Plugin/TechnicalDebt.php
@@ -151,6 +151,7 @@ class TechnicalDebt implements PHPCI\Plugin, PHPCI\ZeroConfigPlugin
 
         $ignores = $this->ignore;
         $ignores[] = 'phpci.yml';
+        $ignores[] = '.phpci.yml';
 
         foreach ($iterator as $file) {
             $filePath = $file->getRealPath();


### PR DESCRIPTION
A lot of other systems such as Travis, StyleCI and Codeclimate use a dotfile to hide to config, so I've tweaked the build process to check for a dotfile if phpci.yml doesn't exist