### PR TITLE
Use variables and set user/group

### DIFF
--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -76,7 +76,7 @@ class CopyBuild implements \PHPCI\Plugin
             }
 
             $cmd = 'chown -R %s "%s"';
-			$this->phpci->log('Setting usergroup '.$usergroup.' for "'.$this->directory.'"');
+            $this->phpci->log('Setting usergroup '.$usergroup.' for "'.$this->directory.'"');
             $success = $this->phpci->executeCommand($cmd, $usergroup, $this->directory);
         }
 

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -66,16 +66,13 @@ class CopyBuild implements \PHPCI\Plugin
 
         $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory);
 
-        if ($success && ( !is_null($this->setuser) || !is_null($this->setgroup) ) !IS_WIN)
-        {
+        if ($success && ( !is_null($this->setuser) || !is_null($this->setgroup) ) !IS_WIN) {
             $usergroup = "";
-            if (!is_null($this->setuser))
-            {
+            if (!is_null($this->setuser)) {
                 $usergroup .= $this->setuser;
             }
 
-            if (!is_null($this->setgroup))
-            {
+            if (!is_null($this->setgroup)) {
                  .= ":".$this->setgroup;
             }
 

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -38,7 +38,7 @@ class CopyBuild implements \PHPCI\Plugin
         $path               = $phpci->buildPath;
         $this->phpci        = $phpci;
         $this->build = $build;
-        $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
+        $this->directory    = isset($options['directory']) ? $this->phpci->interpolate($options['directory']) : $path;
         $this->wipe         = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
         $this->ignore       = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;
         $this->setuser      = isset($options['setuser']) ?  $options['setuser'] : null;
@@ -64,21 +64,23 @@ class CopyBuild implements \PHPCI\Plugin
         }
 
 
-        $success = $this->phpci->executeCommand($cmd, $this->phpci->interpolate($this->directory), $build, $this->phpci->interpolate($this->directory));
+        $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory);
 
-        if($success && (!is_null($this->setuser) || !is_null($this->setgroup)) !IS_WIN)
+        if ($success && ( !is_null($this->setuser) || !is_null($this->setgroup) ) !IS_WIN)
         {
             $usergroup = "";
-            if(!is_null($this->setuser))
+            if (!is_null($this->setuser))
             {
                 $usergroup .= $this->setuser;
             }
-            if(!is_null($this->setgroup))
+
+            if (!is_null($this->setgroup))
             {
                  .= ":".$this->setgroup;
             }
+
             $cmd = 'chown -R %s "%s"';
-            $success = $this->phpci->executeCommand($cmd, $usergroup, $this->phpci->interpolate($this->directory));
+            $success = $this->phpci->executeCommand($cmd, $usergroup, $this->directory);
         }
 
         $this->deleteIgnoredFiles();

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -63,7 +63,7 @@ class CopyBuild implements \PHPCI\Plugin
             $cmd = 'mkdir -p "%s" && xcopy /E "%s" "%s"';
         }
 
-        $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory.'/.');
+        $success = $this->phpci->executeCommand($cmd, $this->directory, $build.'/.', $this->directory);
 
         if ($success && ( !is_null($this->setuser) || !is_null($this->setgroup) ) && !IS_WIN) {
             $usergroup = "";

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -63,20 +63,20 @@ class CopyBuild implements \PHPCI\Plugin
             $cmd = 'mkdir -p "%s" && xcopy /E "%s" "%s"';
         }
 
+        $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory.'/.');
 
-        $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory);
-
-        if ($success && ( !is_null($this->setuser) || !is_null($this->setgroup) ) !IS_WIN) {
+        if ($success && ( !is_null($this->setuser) || !is_null($this->setgroup) ) && !IS_WIN) {
             $usergroup = "";
             if (!is_null($this->setuser)) {
                 $usergroup .= $this->setuser;
             }
 
             if (!is_null($this->setgroup)) {
-                 .= ":".$this->setgroup;
+                $usergroup .= ":".$this->setgroup;
             }
 
             $cmd = 'chown -R %s "%s"';
+			$this->phpci->log('Setting usergroup '.$usergroup.' for "'.$this->directory.'"');
             $success = $this->phpci->executeCommand($cmd, $usergroup, $this->directory);
         }
 


### PR DESCRIPTION
Issue: https://github.com/Block8/PHPCI/issues/1068

enable the copy Build plugin to get variables
(https://github.com/Block8/PHPCI/wiki/Interpolation) in Path and to be
able to set a group / user for the target directory so that it doesn't
belong to the cronjob / deamon user.
