### PR TITLE
Fix Arrangement of Build Result Components

### DIFF
--- a/public/assets/js/build.js
+++ b/public/assets/js/build.js
@@ -108,8 +108,8 @@ var Build = Class.extend({
             output = $('<div class="box-body"></div>').append(output);
         }
 
-        var container = $('<div></div>').addClass('ui-plugin ' + plugin.css);
-        var content = $('<div></div>').attr('id', plugin.id).append(output);
+        var container = $('<div></div>').addClass('ui-plugin ' + plugin.css).attr('id', plugin.id);
+        var content = $('<div></div>').append(output);
         content.addClass('box box-default');
 
         if (plugin.title) {


### PR DESCRIPTION
This will allow the other non-hidden components to properly reflow on the page.