### PR TITLE
Fix Datepicker Locale File Include

### DIFF
--- a/PHPCI/View/layout.phtml
+++ b/PHPCI/View/layout.phtml
@@ -143,7 +143,7 @@
                         <i class="fa fa-dashboard"></i> <span><?php Lang::out('dashboard'); ?></span>
                     </a>
                 </li>
-                
+
                 <?php if ($this->User()->getIsAdmin()): ?>
                     <li class="treeview">
                         <a href="#">
@@ -299,7 +299,9 @@
 
 <script src="<?php print PHPCI_URL; ?>assets/js/plugins/daterangepicker/daterangepicker.js" type="text/javascript"></script>
 <script src="<?php print PHPCI_URL; ?>assets/js/plugins/datepicker/bootstrap-datepicker.js" type="text/javascript"></script>
+<?php if (file_exists(PHPCI_DIR . 'assets/js/plugins/datepicker/locales/bootstrap-datepicker.' . Lang::getLanguage() . '.js')) :?>
 <script src="<?php print PHPCI_URL; ?>assets/js/plugins/datepicker/locales/bootstrap-datepicker.<?php print Lang::getLanguage(); ?>.js" type="text/javascript"></script>
+<?php endif; ?>
 <script src="<?php print PHPCI_URL; ?>assets/js/AdminLTE/app.js" type="text/javascript"></script>
 
 </body>


### PR DESCRIPTION
This addresses some circumstances where there is no language file (like English), which had caused 404 Not Found error.

Reported in issue #999, #903.