### PR TITLE
Add the ability to hide the slack attachment

### DIFF
--- a/PHPCI/Plugin/SlackNotify.php
+++ b/PHPCI/Plugin/SlackNotify.php
@@ -101,7 +101,6 @@ class SlackNotify implements \PHPCI\Plugin
 
         // Include an attachment which shows the status and hide the message
         if ($this->show_status) {
-
             $successfulBuild = $this->build->isSuccessful();
 
             if ($successfulBuild) {


### PR DESCRIPTION
The attachment may not be useful in situations where you customise the message such as using a message in success, failure, fixed or broken rather than complete. For instance you may specifically mention "the build is broken!" so you don't need the attachment repeating it