### PR TITLE
Fixing javascript error when trying to delete a project

### DIFF
--- a/PHPCI/View/Project/view.phtml
+++ b/PHPCI/View/Project/view.phtml
@@ -9,7 +9,7 @@
         <?php Lang::out('edit_project'); ?>
     </a>
 
-    <a  class="btn btn-danger" href="javascript:confirmDelete('<?php print PHPCI_URL . 'project/delete/' . $project->getId(); ?>', '<?php print Lang::out('project'); ?>', true">
+    <a  class="btn btn-danger" href="javascript:confirmDelete('<?php print PHPCI_URL . 'project/delete/' . $project->getId(); ?>', '<?php print Lang::out('project'); ?>', true)">
         <?php Lang::out('delete_project'); ?>
     </a>
 


### PR DESCRIPTION
I am receiving a javascript error when trying to delete a project:

> Uncaught SyntaxError: missing ) after argument list

It seems it is missing a closing `)` on the function call.