### PR TITLE
Adding 

### DIFF
--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -26,6 +26,7 @@ class CopyBuild implements \PHPCI\Plugin
     protected $wipe;
     protected $phpci;
     protected $build;
+    protected $includeDir;
 
     /**
      * Set up the plugin, configure options, etc.
@@ -35,12 +36,13 @@ class CopyBuild implements \PHPCI\Plugin
      */
     public function __construct(Builder $phpci, Build $build, array $options = array())
     {
-        $path            = $phpci->buildPath;
-        $this->phpci     = $phpci;
-        $this->build     = $build;
-        $this->directory = isset($options['directory']) ? $options['directory'] : $path;
-        $this->wipe      = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
-        $this->ignore    = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;
+        $path               = $phpci->buildPath;
+        $this->phpci        = $phpci;
+        $this->build        = $build;
+        $this->directory    = isset($options['directory']) ? $options['directory'] : $path;
+        $this->includeDir   = isset($options['include_build_dir']) ?  $options['include_build_dir'] : true;
+        $this->wipe         = isset($options['wipe']) ?  (bool)$options['wipe'] : false;
+        $this->ignore       = isset($options['respect_ignore']) ?  (bool)$options['respect_ignore'] : false;
     }
 
     /**
@@ -48,6 +50,7 @@ class CopyBuild implements \PHPCI\Plugin
     */
     public function execute()
     {
+
         $build = $this->phpci->buildPath;
 
         if ($this->directory == $build) {
@@ -56,9 +59,20 @@ class CopyBuild implements \PHPCI\Plugin
 
         $this->wipeExistingDirectory();
 
-        $cmd = 'mkdir -p "%s" && cp -R "%s" "%s"';
+        $suffix = '';
+
+        if ($this->includeDir == false) {
+
+            if (substr($build, -1) != DIRECTORY_SEPARATOR) {
+                $build .= DIRECTORY_SEPARATOR;
+            }
+
+            $suffix = "*";
+        }
+
+        $cmd = 'mkdir -p "%s" && cp -R "%s"' . $suffix . ' "%s"';
         if (IS_WIN) {
-            $cmd = 'mkdir -p "%s" && xcopy /E "%s" "%s"';
+            $cmd = 'mkdir -p "%s" && xcopy /E "%s"' . $suffix . ' "%s"';
         }
 
         $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory);

--- a/PHPCI/Plugin/CopyBuild.php
+++ b/PHPCI/Plugin/CopyBuild.php
@@ -72,7 +72,7 @@ class CopyBuild implements \PHPCI\Plugin
 
         $cmd = 'mkdir -p "%s" && cp -R "%s"' . $suffix . ' "%s"';
         if (IS_WIN) {
-            $cmd = 'mkdir -p "%s" && xcopy /E "%s"' . $suffix . ' "%s"';
+            $cmd = 'mkdir -p "%s" && xcopy /E "%s' . $suffix . '" "%s"';
         }
 
         $success = $this->phpci->executeCommand($cmd, $this->directory, $build, $this->directory);


### PR DESCRIPTION
Overview
-----------

Modifying the PHPCI CopyBuild plugin to add an extra option, which indicates whether the root folder of a build should be included when copying it to a destination. The original (and now default) behaviour was that the build folder would always be copied - it is now possible to copy only the build's contents by setting the `include_build_dir` flag to `false`.

Example
-----------

Here's an example of how the copy plugin was defined previously. (This is still valid.)

    success:
        copy_build:
            directory: "/path/to/test.domain.com/"
            wipe: true
            respect_ignore: true

This copies the build directory and everything in it, so if your build directory is called `34_abcdef`, then the path of your built software will be `/path/to/test.domain.com/34_abcdef`. This may not be the intended result.

The new flag, `include_build_dir`, allows users to get around this issue:

    success:
        copy_build:
            directory: "/path/to/test.domain.com/"
            wipe: true
            respect_ignore: true
            include_build_dir: false

In this case, the contents of the build folder will be copied, leaving the build folder itself behind, and the path of the built software will be `/path/to/test.domain.com/`.

*Please note:* While I've done my best to verify the command syntax on Windows using a VM (as you can see from my second commit) I don't have a running PHPCI Windows instance to test this live, though I believe the edit is correct and non-harmful.