### PR TITLE
allow grabbing arbitrary number of commits in a github pull request.

### DIFF
--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -238,7 +238,15 @@ class WebhookController extends \b8\Controller
         $url    = $payload['pull_request']['commits_url'];
         $http   = new \b8\HttpClient();
         $http->setHeaders($headers);
-        $response = $http->get($url);
+
+        //for large pull requests, allow grabbing more then the default number of commits
+        $custom_per_page = \b8\Config::getInstance()->get('phpci.github.per_page');
+        $params = [];
+        if ($custom_per_page) {
+            $params["per_page"] = $custom_per_page;
+        }
+
+        $response = $http->get($url, $params);
 
         // Check we got a success response:
         if (!$response['success']) {


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: webhook controller

Description of change: In github pull request hook, experienced a hard limit of 30 commits returned. This caused the head commit not to be found and the build not to run

Description of solution: Allow optional new `config.yml` setting: `phpci.github.per_page` to be sent to github api
