### PR TITLE
Fixes small bug with language select on the settings page.

### DIFF
--- a/PHPCI/Controller/SettingsController.php
+++ b/PHPCI/Controller/SettingsController.php
@@ -444,7 +444,7 @@ class SettingsController extends Controller
         $field->setClass('form-control');
         $field->setContainerClass('form-group');
         $field->setOptions(Lang::getLanguageOptions());
-        $field->setValue('en');
+        $field->setValue(Lang::getLanguage());
         $form->addField($field);
 
 


### PR DESCRIPTION
Contribution Type: bug fix
Primary Area: front-end

Description of change: Changed the default value of the language select on the settings page.

Description of solution: The default value is now the current language (before: English). The commit 942127f fixed the same bug on the user profile page.