### PR TITLE
Allows Mysql plugin to import with a no-password user

### DIFF
--- a/PHPCI/Plugin/Mysql.php
+++ b/PHPCI/Plugin/Mysql.php
@@ -168,9 +168,9 @@ class Mysql implements \PHPCI\Plugin
             ':decomp_cmd' => $decomp_cmd,
             ':host' => escapeshellarg($this->host),
             ':user' => escapeshellarg($this->user),
-            ':pass' => escapeshellarg($this->pass),
+            ':pass' => (!$this->pass)? '': '-p' . escapeshellarg($this->pass),
             ':database' => ($database === null)? '': escapeshellarg($database),
         );
-        return strtr('cat :import_file :decomp_cmd | mysql -h:host -u:user -p:pass :database', $args);
+        return strtr('cat :import_file :decomp_cmd | mysql -h:host -u:user :pass :database', $args);
     }
 }


### PR DESCRIPTION
When calling a command like `mysql -u'root' -p''`, Mysql will ask for a password. So, the import command will wait during the build process.
To avoid the prompt, check the password and use `mysql -u'root'` instead.
