### PR TITLE
[FIX] #1185 Running Complete stage even on Exception catch.

### DIFF
--- a/PHPCI/Builder.php
+++ b/PHPCI/Builder.php
@@ -213,8 +213,6 @@ class Builder implements LoggerAwareInterface
                 $this->build->setStatus(Build::STATUS_FAILED);
             }
 
-            // Complete stage plugins are always run
-            $this->pluginExecutor->executePlugins($this->config, 'complete');
 
             if ($success) {
                 $this->pluginExecutor->executePlugins($this->config, 'success');
@@ -236,6 +234,9 @@ class Builder implements LoggerAwareInterface
         } catch (\Exception $ex) {
             $this->build->setStatus(Build::STATUS_FAILED);
             $this->buildLogger->logFailure(Lang::get('exception') . $ex->getMessage());
+        }finally{
+            // Complete stage plugins are always run
+            $this->pluginExecutor->executePlugins($this->config, 'complete');
         }
 
 


### PR DESCRIPTION
Contribution Type: **bug fix**
Primary Area: **builder**
Link to Bug: #1185 

Description of change: 
Complete is always executed after test and setup even when an exception is caught

Description of solution: 
The "complete" stage execution has been moved to a finally block in order to be executed no matter the result of setup and test stages.