### PR TITLE
Branch name in build table extended to 250 characters

### DIFF
--- a/PHPCI/Migrations/20160310132732_brach_column_length.php
+++ b/PHPCI/Migrations/20160310132732_brach_column_length.php
@@ -1,0 +1,29 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Column branch in build table extended to 250 characters.
+ */
+class BrachColumnLength extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $table = $this->table('build');
+        $table->changeColumn('branch', 'string', array('limit' => 250));
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $table = $this->table('build');
+        $table->changeColumn('branch', 'string', array('limit' => 50));
+    }
+
+
+}

--- a/PHPCI/Model/Base/BuildBase.php
+++ b/PHPCI/Model/Base/BuildBase.php
@@ -124,7 +124,7 @@ class BuildBase extends Model
         ),
         'branch' => array(
             'type' => 'varchar',
-            'length' => 50,
+            'length' => 250,
             'default' => 'master',
         ),
         'created' => array(

--- a/PHPCI/Model/Base/ProjectBase.php
+++ b/PHPCI/Model/Base/ProjectBase.php
@@ -117,7 +117,7 @@ class ProjectBase extends Model
         ),
         'branch' => array(
             'type' => 'varchar',
-            'length' => 50,
+            'length' => 250,
             'default' => 'master',
         ),
         'ssh_private_key' => array(


### PR DESCRIPTION
Sometimes it happened to me that I have longer branch name and PHPCI then cannot run tests (because of 50 characters limit on branch name).
