### PR TITLE
Update logging of BaseCommandExecutor.php

### DIFF
--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -77,9 +77,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
         $command = call_user_func_array('sprintf', $args);
 
-        if ($this->quiet) {
-            $this->logger->log('Executing: ' . $command);
-        }
+        $this->logger->log('Executing: ' . $command);
 
         $status = 0;
         $descriptorSpec = array(


### PR DESCRIPTION
The $this->quiet thing seems like a mistake. I don't see it use anywhere besides filters, and why would you want to only log things if you set quiet?