### PR TITLE
Fix for PhpCpd plugin

### DIFF
--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -141,7 +141,7 @@ CPD;
                     $message,
                     BuildError::SEVERITY_NORMAL,
                     $fileName,
-                    $file['line'],
+                    (int) $file['line'],
                     (int) $file['line'] + (int) $duplication['lines']
                 );
             }


### PR DESCRIPTION
**Contribution Type**: Bugfix
**Primary Area**: PhpCpd plugin
**Description of change**:  Fixed ValidationException in PhpCpd plugin ($lineStart must be integer, but passed SimpleXMLElement).
