### PR TITLE
Support for codeception errors

### DIFF
--- a/PHPCI/Plugin/Util/TestResultParsers/Codeception.php
+++ b/PHPCI/Plugin/Util/TestResultParsers/Codeception.php
@@ -20,6 +20,7 @@ class Codeception implements ParserInterface
     protected $totalTests;
     protected $totalTimeTaken;
     protected $totalFailures;
+    protected $totalErrors;
 
     /**
      * @param Builder $phpci
@@ -47,6 +48,7 @@ class Codeception implements ParserInterface
             $this->totalTests += (int) $testsuite['tests'];
             $this->totalTimeTaken += (float) $testsuite['time'];
             $this->totalFailures += (int) $testsuite['failures'];
+            $this->totalErrors += (int) $testsuite['errors'];
 
             foreach ($testsuite->testcase as $testcase) {
                 $testresult = array(
@@ -67,9 +69,9 @@ class Codeception implements ParserInterface
                     $testresult['feature'] = sprintf('%s::%s', $testresult['class'], $testresult['name']);
                 }
 
-                if (isset($testcase->failure)) {
+                if (isset($testcase->failure) || isset($testcase->error)) {
                     $testresult['pass'] = false;
-                    $testresult['message'] = (string) $testcase->failure;
+                    $testresult['message'] =  isset($testcase->failure) ? (string) $testcase->failure : (string) $testcase->error;
                 } else {
                     $testresult['pass'] = true;
                 }
@@ -108,6 +110,6 @@ class Codeception implements ParserInterface
      */
     public function getTotalFailures()
     {
-        return $this->totalFailures;
+        return $this->totalFailures + $this->totalErrors;
     }
 }


### PR DESCRIPTION
Whenever a codeception test finishes with an error the test fails but is not counted as a  failure, it is counted as  an error in the report.xml file.  This makes the test  appear  green in the  phpci  UI and it should be red (because in the end the test failed).

This makes hard to test if the codeception plugin is working as expected because even when it fails all the test appear as they passed.

See this image, all the tests passed but the codeception status is marked as failed: 

![error_codeception](https://cloud.githubusercontent.com/assets/33288/14485442/b01f0878-011c-11e6-90eb-ea5bd14e3e57.png)

In this PR I make the plugin be aware of  the errors not just of the failures. 