### PR TITLE
Fix 'CommitterEmail must be a string' err in bitbucket webhook

### DIFF
--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -116,8 +116,11 @@ class WebhookController extends \b8\Controller
         foreach ($payload['push']['changes'] as $commit) {
             try {
                 $email = $commit['new']['target']['author']['raw'];
-                $email = substr($email, 0, strpos($email, '>'));
-                $email = substr($email, strpos($email, '<') + 1);
+                if (strpos($email, '>') !== false) {
+                    // In order not to loose email if it is RAW, w/o "<>" symbols
+                    $email = substr($email, 0, strpos($email, '>'));
+                    $email = substr($email, strpos($email, '<') + 1);
+                }
 
                 $results[$commit['new']['target']['hash']] = $this->createBuild(
                     $project,


### PR DESCRIPTION
Contribution Type: bug fix
Link to Intent to Implement:
Link to Bug:

This pull request affects the following areas:
- [x] Front-End
- [ ] Builder
- [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [x] Do the PHPCI tests pass?

Detailed description of change:
I've noticed that bitbucket fails with message "CommitterEmail must be a string" while trying to push payload to phpci webhook. WebhookController.php was assuming that commit's author email is always like some@mail.com, while in real life email can be without "<>" symbols.
