### PR TITLE
Removed unused 'standard' option for PhpCpd plugin

### DIFF
--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -50,15 +50,10 @@ class PhpCpd implements \PHPCI\Plugin
         $this->build = $build;
 
         $this->path = $phpci->buildPath;
-        $this->standard = 'PSR1';
         $this->ignore = $phpci->ignore;
 
         if (!empty($options['path'])) {
             $this->path = $phpci->buildPath . $options['path'];
-        }
-
-        if (!empty($options['standard'])) {
-            $this->standard = $options['standard'];
         }
 
         if (!empty($options['ignore'])) {


### PR DESCRIPTION
Contribution Type: refactor
Link to Intent to Implement:
Link to Bug:

This pull request affects the following areas:

* [ ] Front-End
* [ ] Builder
* [x] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki. -> see below
- [x] Do the PHPCI tests pass?


Detailed description of change:

The 'standard' option is unused in the PhpCpd plugin, and does not actually make sense for copy-paste-detection.

If this change is merged, the wiki page at https://github.com/block8/phpci/wiki/PHP-Copy-Paste-Detector-Plugin also needs to be updated.


