### PR TITLE
Removing PHPUnit::execute Coverage Tags

### DIFF
--- a/Tests/PHPCI/Helper/MailerFactoryTest.php
+++ b/Tests/PHPCI/Helper/MailerFactoryTest.php
@@ -22,9 +22,6 @@ class MailerFactoryTest extends \PHPUnit_Framework_TestCase
     {
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestGetMailConfig()
     {
         $config = array(
@@ -46,9 +43,6 @@ class MailerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($config['default_mailto_address'], $factory->getMailConfig('default_mailto_address'));
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestMailer()
     {
         $config = array(

--- a/Tests/PHPCI/Model/BuildTest.php
+++ b/Tests/PHPCI/Model/BuildTest.php
@@ -24,9 +24,6 @@ class BuildTest extends \PHPUnit_Framework_TestCase
     {
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestIsAValidModel()
     {
         $build = new Build();
@@ -35,9 +32,6 @@ class BuildTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($build instanceof Model\Base\BuildBase);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestBaseBuildDefaults()
     {
         $build = new Build();
@@ -46,9 +40,6 @@ class BuildTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $build->getFileLinkTemplate());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestIsSuccessful()
     {
         $build = new Build();
@@ -65,9 +56,6 @@ class BuildTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($build->isSuccessful());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestBuildExtra()
     {
         $info = array(

--- a/Tests/PHPCI/Model/ProjectTest.php
+++ b/Tests/PHPCI/Model/ProjectTest.php
@@ -56,7 +56,8 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('master', $project->getBranch());
     }
 
-    public function testExecute_TestBitbucketDefaultBranch() {
+    public function testExecute_TestBitbucketDefaultBranch() 
+    {
         $project = new Project();
         $project->setType('bitbucket');
 

--- a/Tests/PHPCI/Model/ProjectTest.php
+++ b/Tests/PHPCI/Model/ProjectTest.php
@@ -24,9 +24,6 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
     {
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestIsAValidModel()
     {
         $project = new Project();
@@ -35,9 +32,6 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($project instanceof Model\Base\ProjectBase);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestGitDefaultBranch()
     {
         $project = new Project();
@@ -46,9 +40,6 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('master', $project->getBranch());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestGithubDefaultBranch()
     {
         $project = new Project();
@@ -57,9 +48,6 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('master', $project->getBranch());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestGitlabDefaultBranch()
     {
         $project = new Project();
@@ -68,20 +56,13 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('master', $project->getBranch());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
-    public function testExecute_TestBitbucketDefaultBranch()
-    {
+    public function testExecute_TestBitbucketDefaultBranch() {
         $project = new Project();
         $project->setType('bitbucket');
 
         $this->assertEquals('master', $project->getBranch());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestMercurialDefaultBranch()
     {
         $project = new Project();
@@ -90,9 +71,6 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('default', $project->getBranch());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_TestProjectAccessInformation()
     {
         $info = array(

--- a/Tests/PHPCI/Plugin/EmailTest.php
+++ b/Tests/PHPCI/Plugin/EmailTest.php
@@ -164,9 +164,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
             }));
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testReturnsFalseWithoutArgs()
     {
         $this->loadEmailPluginWithOptions();
@@ -179,9 +176,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedReturn, $returnValue);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testBuildsBasicEmails()
     {
         $this->loadEmailPluginWithOptions(
@@ -196,9 +190,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('test-receiver@example.com', $this->message['to']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testBuildsDefaultEmails()
     {
         $this->loadEmailPluginWithOptions(
@@ -213,9 +204,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('default-mailto-address@example.com', $this->message['to']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_UniqueRecipientsFromWithCommitter()
     {
         $this->loadEmailPluginWithOptions(
@@ -233,9 +221,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('test-receiver2@example.com', $this->message['to']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_UniqueRecipientsWithCommitter()
     {
         $this->loadEmailPluginWithOptions(
@@ -252,9 +237,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('committer@test.com', $this->message['to']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testCcDefaultEmails()
     {
         $this->loadEmailPluginWithOptions(
@@ -281,9 +263,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testBuildsCommitterEmails()
     {
         $this->loadEmailPluginWithOptions(
@@ -298,9 +277,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('committer-email@example.com', $this->message['to']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testMailSuccessfulBuildHaveProjectName()
     {
         $this->loadEmailPluginWithOptions(
@@ -316,9 +292,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Test-Project', $this->message['body']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testMailFailingBuildHaveProjectName()
     {
         $this->loadEmailPluginWithOptions(
@@ -334,9 +307,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Test-Project', $this->message['body']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testMailSuccessfulBuildHaveStatus()
     {
         $this->loadEmailPluginWithOptions(
@@ -352,9 +322,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('successful', $this->message['body']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testMailFailingBuildHaveStatus()
     {
         $this->loadEmailPluginWithOptions(
@@ -370,9 +337,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('failed', $this->message['body']);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testMailDeliverySuccess()
     {
         $this->loadEmailPluginWithOptions(
@@ -388,9 +352,6 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $returnValue);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testMailDeliveryFail()
     {
         $this->loadEmailPluginWithOptions(

--- a/Tests/PHPCI/Service/BuildServiceTest.php
+++ b/Tests/PHPCI/Service/BuildServiceTest.php
@@ -41,9 +41,6 @@ class BuildServiceTest extends \PHPUnit_Framework_TestCase
         $this->testedService = new BuildService($this->mockBuildStore);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_CreateBasicBuild()
     {
         $project = new Project();
@@ -65,9 +62,6 @@ class BuildServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Manual', $returnValue->getCommitId());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_CreateBuildWithOptions()
     {
         $project = new Project();
@@ -82,9 +76,6 @@ class BuildServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test@example.com', $returnValue->getCommitterEmail());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_CreateBuildWithExtra()
     {
         $project = new Project();
@@ -96,9 +87,6 @@ class BuildServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1001, $returnValue->getExtra('item1'));
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_CreateDuplicateBuild()
     {
         $build = new Build();
@@ -131,9 +119,6 @@ class BuildServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($build->getExtra('item1'), $returnValue->getExtra('item1'));
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_DeleteBuild()
     {
         $store = $this->getMock('PHPCI\Store\BuildStore');

--- a/Tests/PHPCI/Service/ProjectServiceTest.php
+++ b/Tests/PHPCI/Service/ProjectServiceTest.php
@@ -41,9 +41,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $this->testedService = new ProjectService($this->mockProjectStore);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_CreateBasicProject()
     {
         $returnValue = $this->testedService->createProject('Test Project', 'github', 'block8/phpci');
@@ -54,9 +51,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('master', $returnValue->getBranch());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_CreateProjectWithOptions()
     {
         $options = array(
@@ -78,7 +72,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @link https://github.com/Block8/PHPCI/issues/484
-     * @covers PHPUnit::execute
      */
     public function testExecute_CreateGitlabProjectWithoutPort()
     {
@@ -90,9 +83,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('block8/phpci', $returnValue->getReference());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_UpdateExistingProject()
     {
         $project = new Project();
@@ -107,9 +97,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bitbucket', $returnValue->getType());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_EmptyPublicStatus()
     {
         $project = new Project();
@@ -126,9 +113,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $returnValue->getAllowPublicStatus());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_DeleteProject()
     {
         $store = $this->getMock('PHPCI\Store\ProjectStore');

--- a/Tests/PHPCI/Service/UserServiceTest.php
+++ b/Tests/PHPCI/Service/UserServiceTest.php
@@ -40,9 +40,6 @@ class UserServiceTest extends \PHPUnit_Framework_TestCase
         $this->testedService = new UserService($this->mockUserStore);
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_CreateNonAdminUser()
     {
         $user = $this->testedService->createUser('Test', 'test@example.com', 'testing', 0);
@@ -53,18 +50,12 @@ class UserServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(password_verify('testing', $user->getHash()));
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_CreateAdminUser()
     {
         $user = $this->testedService->createUser('Test', 'test@example.com', 'testing', 1);
         $this->assertEquals(1, $user->getIsAdmin());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_RevokeAdminStatus()
     {
         $user = new User();
@@ -76,9 +67,6 @@ class UserServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $user->getIsAdmin());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_GrantAdminStatus()
     {
         $user = new User();
@@ -90,9 +78,7 @@ class UserServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $user->getIsAdmin());
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
+
     public function testExecute_ChangesPasswordIfNotEmpty()
     {
         $user = new User();
@@ -103,9 +89,6 @@ class UserServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(password_verify('newpassword', $user->getHash()));
     }
 
-    /**
-     * @covers PHPUnit::execute
-     */
     public function testExecute_DoesNotChangePasswordIfEmpty()
     {
         $user = new User();


### PR DESCRIPTION
Contribution Type: bug fix
Link to Bug: [https://github.com/Block8/PHPCI/issues/1250](url)

This pull request affects the following areas:

**In raising this pull request, I confirm the following (please check boxes):**
- [*] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [*] I have checked that another pull request for this purpose does not exist.
- [*] I have considered, and confirmed that this submission will be valuable to others.
- [*] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [*] Do the PHPCI tests pass?

Detailed description of change:

Removed the @covers PHPUnit::execute declaration - no such thing exists in the code and code coverage testing will not finish otherwise.
