### PR TITLE
Fixes a fatal error in the webhook controller when an invalid project…

### DIFF
--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -437,7 +437,7 @@ class WebhookController extends \b8\Controller
     {
         $project = $this->projectStore->getById($projectId);
 
-        if (empty($projectId)) {
+        if (empty($project)) {
             throw new Exception('Project does not exist: ' . $projectId);
         }
 


### PR DESCRIPTION
Contribution Type: bug fix
Link to Bug: N/A

This pull request affects the following areas:
- [ ] Front-End
- [ ] Builder
- [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [x] Do the PHPCI tests pass?

**Detailed description of change:**

Fixes a fatal error in the webhook controller when an invalid project id is given in the URL
