### PR TITLE
insufficient length of the string for the field "message"

### DIFF
--- a/PHPCI/Model/Base/BuildErrorBase.php
+++ b/PHPCI/Model/Base/BuildErrorBase.php
@@ -127,8 +127,7 @@ class BuildErrorBase extends Model
             'default' => null,
         ),
         'message' => array(
-            'type' => 'varchar',
-            'length' => 250,
+            'type' => 'text',
             'default' => null,
         ),
         'created_date' => array(


### PR DESCRIPTION
Contribution Type: bug fix
Link to Intent to Implement:
Link to Bug:

This pull request affects the following areas:

* [ ] Front-End
* [x] Builder
* [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [x] Do the PHPCI tests pass?


Detailed description of change:




error occurs when attempting to write error handling during codeSniffer