### PR TITLE
Fixed: Incorrect build removal if prefer_symlink is used #1187 

### DIFF
--- a/PHPCI/Model/Build.php
+++ b/PHPCI/Model/Build.php
@@ -269,13 +269,20 @@ class Build extends BuildBase
      */
     public function removeBuildDirectory()
     {
-        $buildPath = $this->getBuildPath();
+        // Get the path and remove the trailing slash as this may prompt PHP
+        // to see this as a directory even if it's a link.
+        $buildPath = rtrim($this->getBuildPath(), '/');
 
         if (!$buildPath || !is_dir($buildPath)) {
             return;
         }
 
-        exec(sprintf(IS_WIN ? 'rmdir /S /Q "%s"' : 'rm -Rf "%s"', $buildPath));
+        if (is_link($buildPath)) {
+            // Remove the symlink without using recursive.
+            exec(sprintf(IS_WIN ? 'rmdir /S /Q "%s"' : 'rm "%s"', $buildPath));
+        } else {
+            exec(sprintf(IS_WIN ? 'rmdir /S /Q "%s"' : 'rm -Rf "%s"', $buildPath));
+        }
     }
 
     /**


### PR DESCRIPTION
Contribution Type: bug fix
Link to Intent to Implement: _N/A_
Link to Bug: https://github.com/Block8/PHPCI/issues/1187

This pull request affects the following areas:
- [x] Front-End
- [x] Builder
- [x] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [x] Do the PHPCI tests pass?

Detailed description of change:
Added a test on type of the build location. Depending on whether it is a directory or a symlink, the appropriate command is used to remove the location, the appropriate command is used to remove it, when the build is complete.
