### PR TITLE
Better regex (allow more than two extensions)

### DIFF
--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -76,7 +76,7 @@ class PhpParallelLint implements \PHPCI\Plugin
 
         if (isset($options['extensions'])) {
             // Only use if this is a comma delimited list
-            $pattern = '/^[a-z]*,\ *[a-z]*$/';
+            $pattern = '/^([a-z]+)(,\ *[a-z]*)*$/';
 
             if (preg_match($pattern, $options['extensions'])) {
                 $this->extensions = str_replace(' ', '', $options['extensions']);


### PR DESCRIPTION
Contribution Type: bug fix 
Link to Intent to Implement:
Link to Bug:

This pull request affects the following areas:

* [ ] Front-End
* [ ] Builder
* [X] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [ ] Do the PHPCI tests pass?


Detailed description of change:
The changes made in https://github.com/Block8/PHPCI/pull/1290 checks that the extensions passed in from config are a comma delimited string, but it only allowed one or two extensions.

php would be okay
php, html would be okay
php, html, phtml would be considered to not be valid.

This pull request fixes that.


