### PR TITLE
Fixes issue with branches that start with a hash

### DIFF
--- a/PHPCI/Model/Build/RemoteGitBuild.php
+++ b/PHPCI/Model/Build/RemoteGitBuild.php
@@ -62,7 +62,7 @@ class RemoteGitBuild extends Build
             $cmd .= ' --depth ' . intval($depth) . ' ';
         }
 
-        $cmd .= ' -b %s %s "%s"';
+        $cmd .= ' -b "%s" "%s" "%s"';
         $success = $builder->executeCommand($cmd, $this->getBranch(), $this->getCloneUrl(), $cloneTo);
 
         if ($success) {
@@ -92,7 +92,7 @@ class RemoteGitBuild extends Build
             $cmd .= ' --depth ' . intval($depth) . ' ';
         }
 
-        $cmd .= ' -b %s %s "%s"';
+        $cmd .= ' -b "%s" "%s" "%s"';
 
         if (!IS_WIN) {
             $cmd = 'export GIT_SSH="'.$gitSshWrapper.'" && ' . $cmd;


### PR DESCRIPTION
Contribution Type: bug fix

This pull request affects the following areas:

* [ ] Front-End
* [x] Builder
* [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [ ] Do the PHPCI tests pass?


Detailed description of change: 
Put the branch value into quotes. So special chars like hash (#) in branch names will not effect the git clone command.

