### PR TITLE
problem with plugin PhpCpd

### DIFF
--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -67,21 +67,22 @@ class PhpCpd implements \PHPCI\Plugin
     public function execute()
     {
         $ignore = '';
-        if (count($this->ignore)) {
-            $map = function ($item) {
-                // remove the trailing slash
-                $item = rtrim($item, DIRECTORY_SEPARATOR);
+        $namesExclude = ' --names-exclude ';
+        foreach ($this->ignore as $item) {
+            // remove the trailing slash
+            $item = rtrim($item, DIRECTORY_SEPARATOR);
 
-                if (is_file(rtrim($this->path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $item)) {
-                    return ' --names-exclude ' . $item;
-                } else {
-                    return ' --exclude ' . $item;
-                }
+            if (is_file(rtrim($this->path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $item)) {
+                $ignoredFile = explode('/', $item);
+                $filesToIgnore[] = array_pop($ignoredFile);
+            } else {
+                $ignore .= ' --exclude ' . $item;
+            }
+        }
 
-            };
-            $ignore = array_map($map, $this->ignore);
-
-            $ignore = implode('', $ignore);
+        if (isset($filesToIgnore)) {
+            $filesToIgnore = $namesExclude . implode(',', $filesToIgnore);
+            $ignore = $ignore . $filesToIgnore;
         }
 
         $phpcpd = $this->phpci->findBinary('phpcpd');

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -67,19 +67,21 @@ class PhpCpd implements \PHPCI\Plugin
     public function execute()
     {
         $ignore = '';
-        $namesExclude = ' --names-exclude ';
-        foreach ($this->ignore as $item) {
-            // remove the trailing slash
-            $item = rtrim($item, DIRECTORY_SEPARATOR);
+        if (count($this->ignore)) {
+            $namesExclude = ' --names-exclude ';
+            foreach ($this->ignore as $item) {
+                // remove the trailing slash
+                $item = rtrim($item, DIRECTORY_SEPARATOR);
 
-            if (is_file(rtrim($this->path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $item)) {
-                $ignoredFile = explode('/', $item);
-                $filesToIgnore[] = array_pop($ignoredFile);
-            } else {
-                $ignore .= ' --exclude ' . $item;
+                if (is_file(rtrim($this->path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $item)) {
+                    $ignoredFile = explode('/', $item);
+                    $filesToIgnore[] = array_pop($ignoredFile);
+                } else {
+                    $ignore .= ' --exclude ' . $item;
+                }
             }
         }
-
+        
         if (isset($filesToIgnore)) {
             $filesToIgnore = $namesExclude . implode(',', $filesToIgnore);
             $ignore = $ignore . $filesToIgnore;

--- a/PHPCI/Plugin/PhpCpd.php
+++ b/PHPCI/Plugin/PhpCpd.php
@@ -80,11 +80,11 @@ class PhpCpd implements \PHPCI\Plugin
                     $ignore .= ' --exclude ' . $item;
                 }
             }
-        }
-        
-        if (isset($filesToIgnore)) {
-            $filesToIgnore = $namesExclude . implode(',', $filesToIgnore);
-            $ignore = $ignore . $filesToIgnore;
+
+            if (isset($filesToIgnore)) {
+                $filesToIgnore = $namesExclude . implode(',', $filesToIgnore);
+                $ignore = $ignore . $filesToIgnore;
+            }
         }
 
         $phpcpd = $this->phpci->findBinary('phpcpd');


### PR DESCRIPTION
Problem with plugin: it sends the wrong command to ignore the files. When we ignore
directory, we use --exclude path/dir_1 --exclude path/dir_2 --exclude path/dir_3
everything works correctly but when we want to exclude file - PhpCpd.php
sends command like --names-exclude path/file_1 --names-exclude path/file_2
--names-exlcude path/file_3 and files will be scanned for copy/past, to ignore all three file we have to use command like --names-exclude file_1,file_2,file_3 without paths.

Contribution Type: bug fix 

This pull request affects the following areas:

* [ ] Front-End
* [ ] Builder
* [x] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [ ] Do the PHPCI tests pass?


Detailed description of change:



