### PR TITLE
Proc Open deadlock

### DIFF
--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -102,11 +102,11 @@ abstract class BaseCommandExecutor implements CommandExecutor
             do {
                 usleep(200); //Give It Time To Start
 
-                while(($newData = fread($pipes[1], 1024)) && !feof($pipes[1])) {
+                while (($newData = fread($pipes[1], 1024)) && !feof($pipes[1])) {
                     $lastOutput .= $newData;
                 }
 
-                while(($newData = fread($pipes[2], 1024)) && !feof($pipes[2])) {
+                while (($newData = fread($pipes[2], 1024)) && !feof($pipes[2])) {
                     $lastError .= $newData;
                 }
 

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -95,7 +95,18 @@ abstract class BaseCommandExecutor implements CommandExecutor
         if (is_resource($process)) {
             fclose($pipes[0]);
 
-            $this->lastOutput = stream_get_contents($pipes[1]);
+            $lastOutput = '';
+            do {
+                usleep(200); //Give It Time To Start
+
+                while(($newData = fread($pipes[1], 1024)) && !feof($pipes[1])) {
+                    $lastOutput .= $newData;
+                }
+
+                $processStatus = proc_get_status($process);
+            } while ($processStatus['running']);
+
+            $this->lastOutput = $lastOutput;
             $this->lastError = stream_get_contents($pipes[2]);
 
             fclose($pipes[1]);

--- a/PHPCI/Helper/BaseCommandExecutor.php
+++ b/PHPCI/Helper/BaseCommandExecutor.php
@@ -94,6 +94,7 @@ abstract class BaseCommandExecutor implements CommandExecutor
 
         if (is_resource($process)) {
             fclose($pipes[0]);
+
             stream_set_blocking($pipes[1], 0);
             stream_set_blocking($pipes[2], 0);
 


### PR DESCRIPTION
Contribution Type: bug fix
Link to Intent to Implement: N/A
Link to Bug: N/A

This pull request affects the following areas:

* [ ] Front-End
* [x] Builder
* [x] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [ ] Do the PHPCI tests pass?


Detailed description of change:

When running on a 7.0 repo, I found that it the phpunit test would hang indefinately. When I ran the command directly in the command line, the command ran but died instantly. After a score of R&D, I finally learned that proc_open has a bug in it where if there is a ton of output on both stdout and stderr at the same time, a dead-lock occurs where one is effectively waiting on the other to finish. This change fixes that converting the processing to be non-blocking and instead relying on PHP to check the status. This bypasses the dead-lock and allows the code to run as expected.

