### PR TITLE
ProjectController::build(): Moved the check on project

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -105,12 +105,12 @@ class ProjectController extends PHPCI\Controller
         /* @var \PHPCI\Model\Project $project */
         $project = $this->projectStore->getById($projectId);
 
-        if (empty($branch)) {
-            $branch = $project->getBranch();
-        }
-
         if (empty($project)) {
             throw new NotFoundException(Lang::get('project_x_not_found', $projectId));
+        }
+
+        if (empty($branch)) {
+            $branch = $project->getBranch();
         }
 
         $email = $_SESSION['phpci_user']->getEmail();


### PR DESCRIPTION
ProjectController::build(): Moved the check on whether the project could be found up: no point in trying to get a list of branches of a project that doesn't even exist.

Contribution Type: refactor
Link to Intent to Implement: -
Link to Bug: -

This pull request affects the following areas:

* [x] Front-End
* [ ] Builder
* [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [x] Do the PHPCI tests pass?


Detailed description of change:
Moved the check on whether the project could be found up: no point in trying to get a list of branches of a project that doesn't even exist.


