### PR TITLE
Bugfix: slash in branch name gives 404

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -105,6 +105,10 @@ class ProjectController extends PHPCI\Controller
         /* @var \PHPCI\Model\Project $project */
         $project = $this->projectStore->getById($projectId);
 
+		if ($branch === '' && filter_input(INPUT_GET, 'branch') !== null) {
+			$branch = filter_input(INPUT_GET, 'branch');
+		}
+
         if (empty($branch)) {
             $branch = $project->getBranch();
         }

--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -105,9 +105,9 @@ class ProjectController extends PHPCI\Controller
         /* @var \PHPCI\Model\Project $project */
         $project = $this->projectStore->getById($projectId);
 
-		if ($branch === '' && filter_input(INPUT_GET, 'branch') !== null) {
-			$branch = filter_input(INPUT_GET, 'branch');
-		}
+        if ($branch === '' && filter_input(INPUT_GET, 'branch') !== null) {
+            $branch = filter_input(INPUT_GET, 'branch');
+        }
 
         if (empty($branch)) {
             $branch = $project->getBranch();

--- a/PHPCI/View/Project/view.phtml
+++ b/PHPCI/View/Project/view.phtml
@@ -14,7 +14,7 @@
     </a>
 
     <div class="pull-right btn-group">
-        <a class="btn btn-success" href="<?php print PHPCI_URL . 'project/build/' . $project->getId(); ?><?php echo !empty($branch) ? '/' . urlencode($branch) : '' ?>">
+        <a class="btn btn-success" href="<?php print PHPCI_URL . 'project/build/' . $project->getId(); ?><?php echo !empty($branch) ? '?branch=' . urlencode($branch) : '' ?>">
             <?php Lang::out('build_now'); ?>
         </a>
 


### PR DESCRIPTION
Changes:
.- ProjectController::build: now also checks GET-vars for chosen branch name
.- Project/view: changed link on "build now": when a different branch is chosen, then send it through GET-vars, so slashes are not a problem

Contribution Type: bug fix
Link to Intent to Implement:
Link to Bug:

This pull request affects the following areas:

* [x] Front-End
* [ ] Builder
* [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [x] Do the PHPCI tests pass?


Detailed description of change:
In Git, slashes are allowed in branch names, but when such a branch name is sent in the URL, Apache sends a 404 automatically, unless the AllowEncodedSlashes directive is set.
A solution is to send that variable as GET-var, so instead of /project/build/2/feature%2ffoo%2fbar, we use /project/build/2?branch=feature%2ffoo%2fbar.
Changes:
.- ProjectController::build: now also checks GET-vars for chosen branch name (old behaviour still works)
.- Project/view: changed link on "build now": when a different branch is chosen, then send it through GET-vars, so slashes are not a problem

