### PR TITLE
Plugin Codeception - default path for reports.xml changed in v2.3

### DIFF
--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -45,6 +45,11 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
     protected $path;
 
     /**
+     * @var string $output The directory where codeception stores the report.xml
+     */
+    protected $output;
+
+    /**
      * @param $stage
      * @param Builder $builder
      * @param Build $build
@@ -96,6 +101,8 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
         if (isset($options['path'])) {
             $this->path = $options['path'];
         }
+
+        $this->output = isset($options['output']) ? $options['output'] : '_output';
     }
 
     /**
@@ -143,7 +150,8 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
             Loglevel::DEBUG
         );
 
-        $xml = file_get_contents($this->phpci->buildPath . $this->path . 'report.xml', false);
+        $output = realpath($this->phpci->buildPath . $this->path . $this->output );
+        $xml = file_get_contents($output . DIRECTORY_SEPARATOR . 'report.xml', false);
         $parser = new Parser($this->phpci, $xml);
         $output = $parser->parse();
 

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -145,12 +145,12 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
         $configPath = $this->phpci->buildPath . $configPath;
         $success = $this->phpci->executeCommand($cmd, $this->phpci->buildPath, $configPath);
 
+        $output = realpath($this->phpci->buildPath . $this->path . $this->output);
         $this->phpci->log(
-            'Codeception XML path: '. $this->phpci->buildPath . $this->path . 'report.xml',
+            'Codeception XML path: '. $output . DIRECTORY_SEPARATOR . 'report.xml',
             Loglevel::DEBUG
         );
 
-        $output = realpath($this->phpci->buildPath . $this->path . $this->output);
         $xml = file_get_contents($output . DIRECTORY_SEPARATOR . 'report.xml', false);
         $parser = new Parser($this->phpci, $xml);
         $output = $parser->parse();

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -150,7 +150,7 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
             Loglevel::DEBUG
         );
 
-        $output = realpath($this->phpci->buildPath . $this->path . $this->output );
+        $output = realpath($this->phpci->buildPath . $this->path . $this->output);
         $xml = file_get_contents($output . DIRECTORY_SEPARATOR . 'report.xml', false);
         $parser = new Parser($this->phpci, $xml);
         $output = $parser->parse();


### PR DESCRIPTION
Contribution Type: bug fix
Link to Bug: https://github.com/Block8/PHPCI/issues/1331

This pull request affects the following areas:

* [ ] Front-End
* [ ] Builder
* [x] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [ ] Do the PHPCI tests pass?


Detailed description of change:
Added the option "ouput" for the Codeception plugin. With the output option you may change the directory where to look for the report.xml. By default it will be set to _output/ since Codeception v2.3 stores it here.


