### PR TITLE
Webhook observe configured branches

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -224,6 +224,7 @@ class ProjectController extends PHPCI\Controller
                 'build_config' => $this->getParam('build_config', null),
                 'allow_public_status' => $this->getParam('allow_public_status', 0),
                 'branch' => $this->getParam('branch', null),
+                'observed_branches' => $this->getParam('observed_branches', null),
                 'group' => $this->getParam('group_id', null),
             );
 
@@ -289,6 +290,7 @@ class ProjectController extends PHPCI\Controller
             'allow_public_status' => $this->getParam('allow_public_status', 0),
             'archived' => $this->getParam('archived', 0),
             'branch' => $this->getParam('branch', null),
+            'observed_branches' => $this->getParam('observed_branches', null),
             'group' => $this->getParam('group_id', null),
         );
 

--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -358,6 +358,11 @@ class ProjectController extends PHPCI\Controller
         $field->setClass('form-control')->setContainerClass('form-group')->setValue('master');
         $form->addField($field);
 
+        $field = Form\Element\TextArea::create('observed_branches', Lang::get('observed_branches'), false);
+        $field->setClass('form-control')->setContainerClass('form-group');
+        $field->setRows(6);
+        $form->addField($field);
+
         $field = Form\Element\Select::create('group_id', 'Project Group', true);
         $field->setClass('form-control')->setContainerClass('form-group')->setValue(1);
 

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -463,7 +463,7 @@ class WebhookController extends \b8\Controller
 
         $observedBranches = explode(PHP_EOL, $observedBranchesStr);
         foreach($observedBranches as $observedBranch){
-            if($this->stringContains($branch, $observedBranches)){
+            if($this->stringContains($branch, $observedBranch)){
                 return true;
             }
         }

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -425,7 +425,7 @@ class WebhookController extends \b8\Controller
         $commitMessage,
         array $extra = null
     ) {
-        if(!$this->isBranchObserved($branch, $project)){
+        if( !$this->isBranchObserved($branch, $project) ) {
             return array(
                 'status' => 'ignored',
                 'message' => "Branch \"{$branch}\" is not observed"
@@ -457,13 +457,13 @@ class WebhookController extends \b8\Controller
      */
     protected function isBranchObserved($branch, Project $project)
     {
-        if(($observedBranchesStr = trim($project->getObservedBranches())) === ''){
+        if( ($observedBranchesStr = trim($project->getObservedBranches())) === '' ) {
             return true;
         }
 
         $observedBranches = explode(PHP_EOL, $observedBranchesStr);
-        foreach($observedBranches as $observedBranch){
-            if($this->stringContains($branch, $observedBranch)){
+        foreach( $observedBranches as $observedBranch ){
+            if( $this->stringContains($branch, $observedBranch) ) {
                 return true;
             }
         }
@@ -480,11 +480,11 @@ class WebhookController extends \b8\Controller
      */
     protected function stringContains($str1, $str2)
     {
-        if($str1 === $str2){
+        if( $str1 === $str2 ) {
             return true;
         }
 
-        if(($pos = strrpos($str2, '*')) !== false){
+        if( ($pos = strrpos($str2, '*')) !== false ) {
             return substr($str1, 0, $pos) === substr($str2, 0, $pos);
         }
 

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -425,6 +425,13 @@ class WebhookController extends \b8\Controller
         $commitMessage,
         array $extra = null
     ) {
+        if(!$this->isBranchObserved($branch, $project)){
+            return array(
+                'status' => 'ignored',
+                'message' => "Branch \"{$branch}\" is not observed"
+            );
+        }
+
         // Check if a build already exists for this commit ID:
         $builds = $this->buildStore->getByProjectAndCommit($project->getId(), $commitId);
 
@@ -439,6 +446,49 @@ class WebhookController extends \b8\Controller
         $build = $this->buildService->createBuild($project, $commitId, $branch, $committer, $commitMessage, $extra);
 
         return array('status' => 'ok', 'buildID' => $build->getID());
+    }
+
+    /**
+     * Tells if branch is observed
+     *
+     * @param string $branch
+     * @param Project $project
+     * @return bool
+     */
+    protected function isBranchObserved($branch, Project $project)
+    {
+        if(($observedBranchesStr = trim($project->getObservedBranches())) === ''){
+            return true;
+        }
+
+        $observedBranches = explode(PHP_EOL, $observedBranchesStr);
+        foreach($observedBranches as $observedBranch){
+            if($this->stringContains($branch, $observedBranches)){
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Tells if $str1 contains $str2
+     *
+     * @param string $str1
+     * @param string $str2
+     * @return bool
+     */
+    protected function stringContains($str1, $str2)
+    {
+        if($str1 === $str2){
+            return true;
+        }
+
+        if(($pos = strrpos($str2, '*')) !== false){
+            return substr($str1, 0, $pos) === substr($str2, 0, $pos);
+        }
+
+        return false;
     }
 
     /**

--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -461,8 +461,10 @@ class WebhookController extends \b8\Controller
             return true;
         }
 
+        $replaces = array("\r" => '', "\n" => '');
         $observedBranches = explode(PHP_EOL, $observedBranchesStr);
         foreach( $observedBranches as $observedBranch ){
+            $observedBranch = str_replace(array_keys($replaces), $replaces, $observedBranch);
             if( $this->stringContains($branch, $observedBranch) ) {
                 return true;
             }

--- a/PHPCI/Languages/lang.de.php
+++ b/PHPCI/Languages/lang.de.php
@@ -114,6 +114,7 @@ generiert. Um es zu verwenden, fügen Sie einfach den folgenden Public Key im Ab
     'build_config' => 'PHPCI Buildkonfiguration für dieses Projekt
                                 (falls Sie Ihrem Projektrepository kein phpci.yml hinzufügen können)',
     'default_branch' => 'Name des Standardbranches',
+    'observed_branches' => 'Löse Build über Webhook nur für folgende Branches aus',
     'allow_public_status' => 'Öffentliche Statusseite und -bild für dieses Projekt einschalten?',
     'archived' => 'Archiviert',
     'archived_menu' => 'Archiviert',

--- a/PHPCI/Languages/lang.en.php
+++ b/PHPCI/Languages/lang.en.php
@@ -114,6 +114,7 @@ PHPCI',
     'build_config' => 'PHPCI build config for this project
                                 (if you cannot add a phpci.yml file in the project repository)',
     'default_branch' => 'Default branch name',
+    'observed_branches' => 'Only trigger build via webhook for following branches',
     'allow_public_status' => 'Enable public status page and image for this project?',
     'archived' => 'Archived',
     'archived_menu' => 'Archived',

--- a/PHPCI/Migrations/20170608164202_add_observe_branches_column.php
+++ b/PHPCI/Migrations/20170608164202_add_observe_branches_column.php
@@ -1,0 +1,13 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddObserveBranchesColumn extends AbstractMigration
+{
+    public function change()
+    {
+        $project = $this->table('project');
+        $project->addColumn('observed_branches', 'text');
+        $project->save();
+    }
+}

--- a/PHPCI/Model/Base/ProjectBase.php
+++ b/PHPCI/Model/Base/ProjectBase.php
@@ -37,6 +37,7 @@ class ProjectBase extends Model
         'title' => null,
         'reference' => null,
         'branch' => null,
+        'observed_branches' => null,
         'ssh_private_key' => null,
         'type' => null,
         'access_information' => null,
@@ -57,6 +58,7 @@ class ProjectBase extends Model
         'title' => 'getTitle',
         'reference' => 'getReference',
         'branch' => 'getBranch',
+        'observed_branches' => 'getObservedBranches',
         'ssh_private_key' => 'getSshPrivateKey',
         'type' => 'getType',
         'access_information' => 'getAccessInformation',
@@ -80,6 +82,7 @@ class ProjectBase extends Model
         'title' => 'setTitle',
         'reference' => 'setReference',
         'branch' => 'setBranch',
+        'observed_branches' => 'setObservedBranches',
         'ssh_private_key' => 'setSshPrivateKey',
         'type' => 'setType',
         'access_information' => 'setAccessInformation',
@@ -119,6 +122,11 @@ class ProjectBase extends Model
             'type' => 'varchar',
             'length' => 250,
             'default' => 'master',
+        ),
+        'observed_branches' => array(
+            'type' => 'text',
+            'nullable' => true,
+            'default' => null,
         ),
         'ssh_private_key' => array(
             'type' => 'text',
@@ -234,6 +242,18 @@ class ProjectBase extends Model
     public function getBranch()
     {
         $rtn    = $this->data['branch'];
+
+        return $rtn;
+    }
+
+    /**
+     * Get the value of observed branches
+     *
+     * @return string
+     */
+    public function getObservedBranches()
+    {
+        $rtn    = $this->data['observed_branches'];
 
         return $rtn;
     }
@@ -424,6 +444,26 @@ class ProjectBase extends Model
         $this->data['branch'] = $value;
 
         $this->_setModified('branch');
+    }
+
+    /**
+     * Set the value of Branch / branch.
+     *
+     * Must not be null.
+     * @param $value string
+     */
+    public function setObservedBranches($value)
+    {
+        $this->_validateNotNull('Observed branches', $value);
+        $this->_validateString('Observed branches', $value);
+
+        if ($this->data['observed_branches'] === $value) {
+            return;
+        }
+
+        $this->data['observed_branches'] = $value;
+
+        $this->_setModified('observed_branches');
     }
 
     /**

--- a/PHPCI/Model/Build/GithubBuild.php
+++ b/PHPCI/Model/Build/GithubBuild.php
@@ -13,6 +13,7 @@ use PHPCI\Builder;
 use PHPCI\Helper\Diff;
 use PHPCI\Helper\Github;
 use PHPCI\Model\Build\RemoteGitBuild;
+use PHPCI\Model\BuildError;
 
 /**
 * Github Build Model

--- a/PHPCI/Model/Build/GithubBuild.php
+++ b/PHPCI/Model/Build/GithubBuild.php
@@ -200,7 +200,7 @@ class GithubBuild extends RemoteGitBuild
         $lineStart = null,
         $lineEnd = null
     ) {
-        $diffLineNumber = $this->getDiffLineNumber($builder, $file, $lineStart);
+        $diffLineNumber = $file === null ? null : $this->getDiffLineNumber($builder, $file, $lineStart);
 
         if (!is_null($diffLineNumber)) {
             $helper = new Github();

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -45,6 +45,11 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
     protected $path;
 
     /**
+     * @var string $output The directory where codeception stores the report.xml
+     */
+    protected $output;
+
+    /**
      * @param $stage
      * @param Builder $builder
      * @param Build $build
@@ -96,6 +101,8 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
         if (isset($options['path'])) {
             $this->path = $options['path'];
         }
+
+        $this->output = isset($options['output']) ? $options['output'] : '_output';
     }
 
     /**
@@ -143,7 +150,8 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
             Loglevel::DEBUG
         );
 
-        $xml = file_get_contents($this->phpci->buildPath . $this->path . 'report.xml', false);
+        $output = realpath($this->phpci->buildPath . $this->path . $this->output );
+        $xml = file_get_contents($output . DIRECTORY_SEPARATOR . 'report.xml', false);
         $parser = new Parser($this->phpci, $xml);
         $output = $parser->parse();
 

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -145,12 +145,12 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
         $configPath = $this->phpci->buildPath . $configPath;
         $success = $this->phpci->executeCommand($cmd, $this->phpci->buildPath, $configPath);
 
+        $output = realpath($this->phpci->buildPath . $this->path . $this->output);
         $this->phpci->log(
-            'Codeception XML path: '. $this->phpci->buildPath . $this->path . 'report.xml',
+            'Codeception XML path: '. $output . DIRECTORY_SEPARATOR . 'report.xml',
             Loglevel::DEBUG
         );
 
-        $output = realpath($this->phpci->buildPath . $this->path . $this->output);
         $xml = file_get_contents($output . DIRECTORY_SEPARATOR . 'report.xml', false);
         $parser = new Parser($this->phpci, $xml);
         $output = $parser->parse();

--- a/PHPCI/Plugin/Codeception.php
+++ b/PHPCI/Plugin/Codeception.php
@@ -150,7 +150,7 @@ class Codeception implements \PHPCI\Plugin, \PHPCI\ZeroConfigPlugin
             Loglevel::DEBUG
         );
 
-        $output = realpath($this->phpci->buildPath . $this->path . $this->output );
+        $output = realpath($this->phpci->buildPath . $this->path . $this->output);
         $xml = file_get_contents($output . DIRECTORY_SEPARATOR . 'report.xml', false);
         $parser = new Parser($this->phpci, $xml);
         $output = $parser->parse();

--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -89,6 +89,10 @@ class ProjectService
             $project->setBranch($options['branch']);
         }
 
+        if (array_key_exists('observed_branches', $options)) {
+            $project->setObservedBranches($options['observed_branches']);
+        }
+
         if (array_key_exists('group', $options)) {
             $project->setGroup($options['group']);
         }


### PR DESCRIPTION
Contribution Type: new feature

This pull request affects the following areas:

* [x] Front-End
* [x] Builder
* [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [ ] Do the PHPCI tests pass?


Detailed description of change:

When working with GIT webhooks every commit of every contributor triggers a build in PHPCI. As I have very time consuming acceptance tests with Codeception and my contributors are pushing a lot of stuff PHPCI is always very busy. For me there is no need to run all tests for every commit on every branch. Important for me is my master branch and my release candidate branches where I put all branches of my contributors together to see if it works. 
So I've added a textarea with the name "observed_branches" to the project configuration page. 
Before a build is triggered via webhook by WebhookController::createBuild I check if the requestet branch is in the projects branch observation by getting the text from "observed_branches" and exploding it by PHP_EOL. After that I'll check if the branch name submitted by the webhook is in my exploded array. If not I will not create the build. 
If the project option "observed_branches" is empty all incoming branch names are triggering a build creation as it is now.
You may also use the * sign as a wildcard for branch names when configuring the "observed_branches" option, as I use this for my RC branches. For example a configuration like 

```
master
rc-*
```
would accept a build creation via webhook for the "master" branch and all branch names starting with "rc-"

Maybe this can be helpful to others.

![branchobservation](https://user-images.githubusercontent.com/18677661/26955379-a3988534-4cb6-11e7-9c45-56bf325db21a.PNG)
![branchobservationwebhookignored](https://user-images.githubusercontent.com/18677661/26955417-e6aad480-4cb6-11e7-9c1f-4bc311be36ac.PNG)



