### PR TITLE
PHP-Parallel-Lint shorttags option

### DIFF
--- a/PHPCI/Plugin/PhpParallelLint.php
+++ b/PHPCI/Plugin/PhpParallelLint.php
@@ -47,11 +47,17 @@ class PhpParallelLint implements \PHPCI\Plugin
     protected $extensions;
 
     /**
+     * @var bool - enable short tags
+     */
+    protected $shortTag;
+
+    /**
      * Standard Constructor
      *
      * $options['directory']  Output Directory. Default: %BUILDPATH%
      * $options['filename']   Phar Filename. Default: build.phar
      * $options['extensions'] Filename extensions. Default: php
+     * $options['shorttags']  Enable short tags. Default: false
      * $options['stub']       Stub Content. No Default Value
      *
      * @param Builder $phpci
@@ -65,6 +71,7 @@ class PhpParallelLint implements \PHPCI\Plugin
         $this->directory = $phpci->buildPath;
         $this->ignore = $this->phpci->ignore;
         $this->extensions = 'php';
+        $this->shortTag = false;
 
         if (isset($options['directory'])) {
             $this->directory = $phpci->buildPath.$options['directory'];
@@ -72,6 +79,10 @@ class PhpParallelLint implements \PHPCI\Plugin
 
         if (isset($options['ignore'])) {
             $this->ignore = $options['ignore'];
+        }
+
+        if (isset($options['shorttags'])) {
+            $this->shortTag = (strtolower($options['shorttags']) == 'true');
         }
 
         if (isset($options['extensions'])) {
@@ -93,10 +104,11 @@ class PhpParallelLint implements \PHPCI\Plugin
 
         $phplint = $this->phpci->findBinary('parallel-lint');
 
-        $cmd = $phplint . ' -e %s' . ' %s "%s"';
+        $cmd = $phplint . ' -e %s' . '%s %s "%s"';
         $success = $this->phpci->executeCommand(
             $cmd,
             $this->extensions,
+            ($this->shortTag ? ' -s' : ''),
             $ignore,
             $this->directory
         );


### PR DESCRIPTION
Contribution Type: new feature
Link to Intent to Implement:
Link to Bug: https://github.com/Block8/PHPCI/issues/1339

This pull request affects the following areas:

* [ ] Front-End
* [ ] Builder
* [X] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [ ] Do the PHPCI tests pass?

Detailed description of change:

Add the option to pass the short tags (-s) argument to PHP Parallel Lint so that files using PHP Short Tags can be linted.

