### PR TITLE
Add support for rebuild on Git webhook

### DIFF
--- a/PHPCI/Controller/WebhookController.php
+++ b/PHPCI/Controller/WebhookController.php
@@ -178,8 +178,9 @@ class WebhookController extends \b8\Controller
         $commit = $this->getParam('commit');
         $commitMessage = $this->getParam('message');
         $committer = $this->getParam('committer');
+        $rebuild = $this->getParam('rebuild') ?? false;
 
-        return $this->createBuild($project, $commit, $branch, $committer, $commitMessage);
+        return $this->createBuild($project, $commit, $branch, $committer, $commitMessage, $rebuild);
     }
 
     /**
@@ -325,7 +326,7 @@ class WebhookController extends \b8\Controller
                     'remote_url' => $payload['pull_request']['head']['repo'][$remoteUrlKey],
                 );
 
-                $results[$id] = $this->createBuild($project, $id, $branch, $committer, $message, $extra);
+                $results[$id] = $this->createBuild($project, $id, $branch, $committer, $message, false, $extra);
                 $status = 'ok';
             } catch (Exception $ex) {
                 $results[$id] = array('status' => 'failed', 'error' => $ex->getMessage());
@@ -411,6 +412,7 @@ class WebhookController extends \b8\Controller
      * @param string $branch
      * @param string $committer
      * @param string $commitMessage
+     * @param bool $rebuild
      * @param array $extra
      *
      * @return array
@@ -423,16 +425,19 @@ class WebhookController extends \b8\Controller
         $branch,
         $committer,
         $commitMessage,
+        bool $rebuild = false,
         array $extra = null
     ) {
-        // Check if a build already exists for this commit ID:
-        $builds = $this->buildStore->getByProjectAndCommit($project->getId(), $commitId);
+        // Check if a build already exists for this commit ID when not rebuilding:
+        if (!$rebuild) {
+            $builds = $this->buildStore->getByProjectAndCommit($project->getId(), $commitId);
 
-        if ($builds['count']) {
-            return array(
-                'status' => 'ignored',
-                'message' => sprintf('Duplicate of build #%d', $builds['items'][0]->getId())
-            );
+            if ($builds['count']) {
+                return array(
+                    'status' => 'ignored',
+                    'message' => sprintf('Duplicate of build #%d', $builds['items'][0]->getId())
+                );
+            }
         }
 
         // If not, create a new build job for it:


### PR DESCRIPTION
Enables for example a maintainer to run a daily build of their project,
whether a change has been made or not. The rebuild parameter is made
fully optional.

Contribution Type: new feature

This pull request affects the following areas:

* [x] Front-End
* [ ] Builder
* [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [ ] Do the PHPCI tests pass?


Detailed description of change:

An optional parameter `rebuild` has been added to `WebhookController::createBuild`. This allows a maintainer to use the git webhook to start a rebuild of their project. At our project we want an automatic daily build of the project and this feature supports it.

In `WebhookController::git` the parameter `rebuild` can be read, where it is `false` if no parameter has been given. The parameter `$rebuild` is then passed to `WebhookController::createBuild`. There the parameter `$rebuild` is also made optional and `false` by default, such that other calls to `createBuild` are still supported.

