### PR TITLE
Fix mercurial build by ssh connection

### DIFF
--- a/PHPCI/Model/Build/MercurialBuild.php
+++ b/PHPCI/Model/Build/MercurialBuild.php
@@ -42,7 +42,7 @@ class MercurialBuild extends Build
         }
 
         if (!$success) {
-            $builder->logFailure('Failed to clone remote git repository.');
+            $builder->logFailure('Failed to clone remote mercurial repository.');
             return false;
         }
 
@@ -62,7 +62,7 @@ class MercurialBuild extends Build
      */
     protected function cloneBySsh(Builder $builder, $cloneTo)
     {
-        $keyFile = $this->writeSshKey();
+        $keyFile = $this->writeSshKey($cloneTo);
 
         // Do the git clone:
         $cmd = 'hg clone --ssh "ssh -i '.$keyFile.'" %s "%s"';
@@ -75,6 +75,22 @@ class MercurialBuild extends Build
         // Remove the key file:
         unlink($keyFile);
         return $success;
+    }
+
+    /**
+     * Create an SSH key file on disk for this build.
+     * @param $cloneTo
+     * @return string
+     */
+    protected function writeSshKey($cloneTo)
+    {
+        $keyPath = dirname($cloneTo . '/temp');
+        $keyFile = $keyPath . '.key';
+        // Write the contents of this project's git key to the file:
+        file_put_contents($keyFile, $this->getProject()->getSshPrivateKey());
+        chmod($keyFile, 0600);
+        // Return the filename:
+        return $keyFile;
     }
 
     /**


### PR DESCRIPTION
Contribution Type: bug fix
Link to Intent to Implement: -
Link to Bug: -

This pull request affects the following areas:

* [ ] Front-End
* [x] Builder
* [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [x] Do the PHPCI tests pass?


Detailed description of change:

Fix clone by ssh method for mercurial build

