### PR TITLE
fix regex for parsing gitlab access informations

### DIFF
--- a/PHPCI/Service/ProjectService.php
+++ b/PHPCI/Service/ProjectService.php
@@ -123,12 +123,12 @@ class ProjectService
         if ($project->getType() == 'gitlab') {
             $info = array();
 
-            if (preg_match('`^(.+)@(.+):([0-9]*)\/?(.+)\.git`', $reference, $matches)) {
+            if (preg_match('`^(.+)@(.+):(([0-9]*)\/)?\/?(.+)\.git`', $reference, $matches)) {
                 $info['user'] = $matches[1];
                 $info['domain'] = $matches[2];
-                $info['port'] = $matches[3];
+                $info['port'] = $matches[4];
 
-                $project->setReference($matches[4]);
+                $project->setReference($matches[5]);
             }
 
             $project->setAccessInformation($info);

--- a/Tests/PHPCI/Service/ProjectServiceTest.php
+++ b/Tests/PHPCI/Service/ProjectServiceTest.php
@@ -125,4 +125,26 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(true, $service->deleteProject($project));
     }
+
+
+    public function testExecute_CreateGitlabProjectWithNumberInVendor()
+    {
+        $reference = 'git@gitlab.block8.net:8block/phpci.git';
+        $returnValue = $this->testedService->createProject('Gitlab', 'gitlab', $reference);
+
+        $this->assertEquals('git', $returnValue->getAccessInformation('user'));
+        $this->assertEquals('gitlab.block8.net', $returnValue->getAccessInformation('domain'));
+        $this->assertEquals('8block/phpci', $returnValue->getReference());
+    }
+
+    public function testExecute_CreateGitlabProjectWithPortAndNumberInVendor()
+    {
+        $reference = 'git@gitlab.block8.net:22/8block/phpci.git';
+        $returnValue = $this->testedService->createProject('Gitlab', 'gitlab', $reference);
+
+        $this->assertEquals('git', $returnValue->getAccessInformation('user'));
+        $this->assertEquals('gitlab.block8.net', $returnValue->getAccessInformation('domain'));
+        $this->assertEquals(22, $returnValue->getAccessInformation('port'));
+        $this->assertEquals('8block/phpci', $returnValue->getReference());
+    }
 }


### PR DESCRIPTION
Contribution Type: bug fix 
Link to Intent to Implement: none
Link to Bug: https://github.com/dancryer/PHPCI/issues/1143

This pull request affects the following areas:

* [ ] Front-End
* [x] Builder
* [ ] Build Plugins

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I have created or updated the relevant documentation for this change on the PHPCI Wiki.
- [x] Do the PHPCI tests pass?


Detailed description of change:
- changed regex for correct parse ports and vendors starting with number .
- added 2 tests for parsing gitlab ssh address.

